### PR TITLE
Updated minimum Rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ Rust bindings for the NumPy C-API
 
 
 ## Requirements
-- current nightly rust (see https://github.com/PyO3/pyo3/issues/5 for nightly features, and
-https://github.com/PyO3/pyo3/blob/master/build.rs for minimum required version)
-- some rust libraries
+- Rust 1.39
+- Some Rust libraries
   - [ndarray](https://github.com/bluss/ndarray) for rust-side matrix library
   - [pyo3](https://github.com/PyO3/pyo3) for cpython binding
   - and more (see [Cargo.toml](Cargo.toml))


### PR DESCRIPTION
Not sure if `Rust 1.39+`, `Rust >=1.39` or something like `minimum...` is needed.
See https://github.com/PyO3/pyo3/issues/5#issuecomment-647094806.
https://github.com/PyO3/pyo3/commit/7075827a038826222bbc9cb6153a1d7455396531 (https://github.com/PyO3/pyo3/pull/989) is blocking this from being merged.