### PR TITLE
Introduce PyReadOnlyArray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ rusty-tags.*
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
 
-# cargo fmt
-*.bk
+# Some Python specific files
 .tox/
+build/
+*.so
+*.egg-info/
+**/dist/
+__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
+<<<<<<< HEAD
 - v0.10.0
   - Remove `ErrorKind` and introduce some concrete error types
+=======
+- Unreleased
+  - `PyArray::as_slice_mut` and `PyArray::as_array_mut` is now unsafe.
+  - Introduce `PyArray::as_cell_slice`, `PyArray::as_cow_array` and `PyArray::to_vec`
+>>>>>>> 660f04f... Overhaul conversion methods
 
 - v0.9.0
   - Update PyO3 to 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 # Changelog
-<<<<<<< HEAD
 - v0.10.0
   - Remove `ErrorKind` and introduce some concrete error types
-=======
-- Unreleased
-  - `PyArray::as_slice_mut` and `PyArray::as_array_mut` is now unsafe.
-  - Introduce `PyArray::as_cell_slice`, `PyArray::as_cow_array` and `PyArray::to_vec`
->>>>>>> 660f04f... Overhaul conversion methods
+  - `PyArray::as_slice`, `PyArray::as_slice_mut`, `PyArray::as_array`, and `PyArray::as_array_mut` is now unsafe.
+  - Introduce `PyArray::as_cell_slice`, `PyArray::to_vec`, and `PyArray::to_owned_array`
 
 - v0.9.0
   - Update PyO3 to 0.10.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ default = []
 # This is no longer needed but setuptools-rust assumes this feature
 python3 = ["pyo3/python3"]
 
+
+[workspace]
+members = ["examples/*"]

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
     // wrapper of `mult`
     #[pyfn(m, "mult")]
     fn mult_py(_py: Python, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
-        let x = x.as_array_mut();
+        let x = unsafe { x.as_array_mut() };
         mult(a, x);
         Ok(())
     }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ fn main_<'py>(py: Python<'py>) -> PyResult<()> {
     let pyarray: &PyArray1<i32> = py
         .eval("np.absolute(np.array([-1, -2, -3], dtype='int32'))", Some(&dict), None)?
         .extract()?;
-    let slice = pyarray.as_slice()?;
+    let readonly = pyarray.readonly();
+    let slice = readonly.as_slice().unwrap();
     assert_eq!(slice, &[1, 2, 3]);
     Ok(())
 }
@@ -109,37 +110,37 @@ features = ["extension-module"]
 
 ```rust
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyArray, PyArrayDyn};
-use pyo3::prelude::{pymodule, Py, PyModule, PyResult, Python};
+use numpy::{IntoPyArray, PyArrayDyn, PyReadonlyArrayDyn};
+use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
 
 #[pymodule]
-fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
+fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // immutable example
-    fn axpy(a: f64, x: ArrayViewD<f64>, y: ArrayViewD<f64>) -> ArrayD<f64> {
+    fn axpy(a: f64, x: ArrayViewD<'_, f64>, y: ArrayViewD<'_, f64>) -> ArrayD<f64> {
         a * &x + &y
     }
 
     // mutable example (no return)
-    fn mult(a: f64, mut x: ArrayViewMutD<f64>) {
+    fn mult(a: f64, mut x: ArrayViewMutD<'_, f64>) {
         x *= a;
     }
 
     // wrapper of `axpy`
     #[pyfn(m, "axpy")]
-    fn axpy_py(
-        py: Python,
+    fn axpy_py<'py>(
+        py: Python<'py>,
         a: f64,
-        x: &PyArrayDyn<f64>,
-        y: &PyArrayDyn<f64>,
-    ) -> Py<PyArrayDyn<f64>> {
+        x: PyReadonlyArrayDyn<f64>,
+        y: PyReadonlyArrayDyn<f64>,
+    ) -> &'py PyArrayDyn<f64> {
         let x = x.as_array();
         let y = y.as_array();
-        axpy(a, x, y).into_pyarray(py).to_owned()
+        axpy(a, x, y).into_pyarray(py)
     }
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
-    fn mult_py(_py: Python, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
+    fn mult_py(_py: Python<'_>, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
         let x = unsafe { x.as_array_mut() };
         mult(a, x);
         Ok(())

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,5 +1,0 @@
-build/
-*.so
-*.egg-info/
-**/dist/
-__pycache__

--- a/examples/simple-extension/src/lib.rs
+++ b/examples/simple-extension/src/lib.rs
@@ -1,6 +1,6 @@
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyArray, PyArrayDyn};
-use pyo3::prelude::{pymodule, Py, PyModule, PyResult, Python};
+use numpy::{IntoPyArray, PyArrayDyn, PyReadonlyArrayDyn};
+use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
 
 #[pymodule]
 fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -16,21 +16,21 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 
     // wrapper of `axpy`
     #[pyfn(m, "axpy")]
-    fn axpy_py(
-        py: Python<'_>,
+    fn axpy_py<'py>(
+        py: Python<'py>,
         a: f64,
-        x: &PyArrayDyn<f64>,
-        y: &PyArrayDyn<f64>,
-    ) -> Py<PyArrayDyn<f64>> {
+        x: PyReadonlyArrayDyn<f64>,
+        y: PyReadonlyArrayDyn<f64>,
+    ) -> &'py PyArrayDyn<f64> {
         let x = x.as_array();
         let y = y.as_array();
-        axpy(a, x, y).into_pyarray(py).to_owned()
+        axpy(a, x, y).into_pyarray(py)
     }
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
     fn mult_py(_py: Python<'_>, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
-        let x = x.as_array_mut();
+        let x = unsafe { x.as_array_mut() };
         mult(a, x);
         Ok(())
     }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -20,7 +20,7 @@ use crate::npyffi::npy_intp;
 /// use numpy::{PyArray, IntoPyArray};
 /// let gil = pyo3::Python::acquire_gil();
 /// let py_array = vec![1, 2, 3].into_pyarray(gil.python());
-/// assert_eq!(py_array.as_slice().unwrap(), &[1, 2, 3]);
+/// assert_eq!(py_array.readonly().as_slice().unwrap(), &[1, 2, 3]);
 /// assert!(py_array.resize(100).is_err()); // You can't resize owned-by-rust array.
 /// ```
 pub trait IntoPyArray {
@@ -71,7 +71,7 @@ where
 /// use numpy::{PyArray, ToPyArray};
 /// let gil = pyo3::Python::acquire_gil();
 /// let py_array = vec![1, 2, 3].to_pyarray(gil.python());
-/// assert_eq!(py_array.as_slice().unwrap(), &[1, 2, 3]);
+/// assert_eq!(py_array.readonly().as_slice().unwrap(), &[1, 2, 3]);
 /// ```
 ///
 /// This method converts a not-contiguous array to C-order contiguous array.
@@ -87,7 +87,7 @@ where
 /// let sliced = arr3(&[[[ 1,  2,  3]],
 ///                     [[ 7,  8,  9]]]);
 /// let py_slice = slice.to_pyarray(py);
-/// assert_eq!(py_slice.as_array(), sliced);
+/// assert_eq!(py_slice.readonly().as_array(), sliced);
 /// pyo3::py_run!(py, py_slice, "assert py_slice.flags['C_CONTIGUOUS']");
 /// ```
 pub trait ToPyArray {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!     let py = gil.python();
 //!     let py_array = array![[1i64, 2], [3, 4]].to_pyarray(py);
 //!     assert_eq!(
-//!         py_array.as_array(),
+//!         py_array.readonly().as_array(),
 //!         array![[1i64, 2], [3, 4]]
 //!     );
 //! }
@@ -40,6 +40,7 @@ pub mod array;
 pub mod convert;
 mod error;
 pub mod npyffi;
+mod readonly;
 mod slice_box;
 pub mod types;
 
@@ -50,6 +51,10 @@ pub use crate::array::{
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 pub use crate::error::{FromVecError, NotContiguousError, ShapeError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
+pub use crate::readonly::{
+    PyReadonlyArray, PyReadonlyArray1, PyReadonlyArray2, PyReadonlyArray3, PyReadonlyArray4,
+    PyReadonlyArray5, PyReadonlyArray6, PyReadonlyArrayDyn,
+};
 pub use crate::types::{c32, c64, NpyDataType, TypeNum};
 pub use ndarray::{Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -25,7 +25,7 @@ const CAPSULE_NAME: &str = "_ARRAY_API";
 /// unsafe {
 ///     PY_ARRAY_API.PyArray_Sort(array.as_array_ptr(), 0, NPY_SORTKIND::NPY_QUICKSORT);
 /// }
-/// assert_eq!(array.as_slice().unwrap(), &[2, 3, 4]);
+/// assert_eq!(array.readonly().as_slice().unwrap(), &[2, 3, 4]);
 /// ```
 pub static PY_ARRAY_API: PyArrayAPI = PyArrayAPI::new();
 

--- a/src/readonly.rs
+++ b/src/readonly.rs
@@ -1,0 +1,164 @@
+//! Readonly arrays
+use crate::npyffi::NPY_ARRAY_WRITEABLE;
+use crate::{NotContiguousError, PyArray, TypeNum};
+use ndarray::{ArrayView, Dimension, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
+use pyo3::{prelude::*, types::PyAny, AsPyPointer};
+
+/// Readonly reference of [`PyArray`](../array/struct.PyArray.html).
+///
+/// This struct ensures that the internal array is not writeable while holding `PyReadonlyArray`.
+/// We use a simple trick for this: modifying the internal flag of the array when creating
+/// `PyReadonlyArray` and recover the original flag when it drops.
+///
+/// So, importantly, it does not recover the original flag when it does not drop
+/// (e.g.,  by the use of `IntoPy::intopy` or `std::mem::forget`)
+/// and then the internal array remains readonly.
+///
+/// # Example
+/// In this example, we get a 'temporal' readonly array and the internal array
+/// becomes writeble again after it drops.
+/// ```
+/// use numpy::{PyArray, npyffi::NPY_ARRAY_WRITEABLE};
+/// let gil = pyo3::Python::acquire_gil();
+/// let py = gil.python();
+/// let py_array = PyArray::arange(py, 0, 4, 1).reshape([2, 2]).unwrap();
+/// {
+///    let readonly = py_array.readonly();
+///    // The internal array is not writeable now.
+///    pyo3::py_run!(py, py_array, "assert not py_array.flags['WRITEABLE']");
+/// }
+/// // After `readonly` drops, the internal array gets writeable again.
+/// pyo3::py_run!(py, py_array, "assert py_array.flags['WRITEABLE']");
+/// ```
+/// However, if we convert the `PyReadonlyArray` directly into `PyObject`,
+/// the internal array remains readonly.
+/// ```
+/// use numpy::{PyArray, npyffi::NPY_ARRAY_WRITEABLE};
+/// use pyo3::{IntoPy, PyObject, Python};
+/// let gil = Python::acquire_gil();
+/// let py = gil.python();
+/// let py_array = PyArray::arange(py, 0, 4, 1).reshape([2, 2]).unwrap();
+/// let obj: PyObject = {
+///    let readonly = py_array.readonly();
+///    // The internal array is not writeable now.
+///    pyo3::py_run!(py, py_array, "assert not py_array.flags['WRITEABLE']");
+///    readonly.into_py(py)
+/// };
+/// // The internal array remains readonly.
+/// pyo3::py_run!(py, py_array, "assert py_array.flags['WRITEABLE']");
+/// ```
+pub struct PyReadonlyArray<'py, T, D> {
+    array: &'py PyArray<T, D>,
+    was_writeable: bool,
+}
+
+impl<'py, T: TypeNum, D: Dimension> PyReadonlyArray<'py, T, D> {
+    /// Returns the immutable view of the internal data of `PyArray` as slice.
+    ///
+    /// Returns `ErrorKind::NotContiguous` if the internal array is not contiguous.
+    /// # Example
+    /// ```
+    /// use numpy::{PyArray, PyArray1};
+    /// use pyo3::types::IntoPyDict;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let py = gil.python();
+    /// let py_array = PyArray::arange(py, 0, 4, 1).reshape([2, 2]).unwrap();
+    /// let readonly = py_array.readonly();
+    /// assert_eq!(readonly.as_slice().unwrap(), &[0, 1, 2, 3]);
+    /// let locals = [("np", numpy::get_array_module(py).unwrap())].into_py_dict(py);
+    /// let not_contiguous: &PyArray1<i32> = py
+    ///     .eval("np.arange(10)[::2]", Some(locals), None)
+    ///     .unwrap()
+    ///     .downcast()
+    ///     .unwrap();
+    /// assert!(not_contiguous.readonly().as_slice().is_err());
+    /// ```
+    pub fn as_slice(&self) -> Result<&[T], NotContiguousError> {
+        unsafe { self.array.as_slice() }
+    }
+
+    /// Get the immutable view of the internal data of `PyArray`, as
+    /// [`ndarray::ArrayView`](https://docs.rs/ndarray/latest/ndarray/type.ArrayView.html).
+    ///
+    /// # Example
+    /// ```
+    /// # #[macro_use] extern crate ndarray;
+    /// use numpy::PyArray;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let py = gil.python();
+    /// let array = PyArray::arange(py, 0, 4, 1).reshape([2, 2]).unwrap();
+    /// let readonly = array.readonly();
+    /// assert_eq!(readonly.as_array(), array![[0, 1], [2, 3]]);
+    /// ```
+    pub fn as_array(&self) -> ArrayView<'_, T, D> {
+        unsafe { self.array.as_array() }
+    }
+}
+
+/// one-dimensional readonly array
+pub type PyReadonlyArray1<'py, T> = PyReadonlyArray<'py, T, Ix1>;
+/// two-dimensional readonly array
+pub type PyReadonlyArray2<'py, T> = PyReadonlyArray<'py, T, Ix2>;
+/// three-dimensional readonly array
+pub type PyReadonlyArray3<'py, T> = PyReadonlyArray<'py, T, Ix3>;
+/// four-dimensional readonly array
+pub type PyReadonlyArray4<'py, T> = PyReadonlyArray<'py, T, Ix4>;
+/// five-dimensional readonly array
+pub type PyReadonlyArray5<'py, T> = PyReadonlyArray<'py, T, Ix5>;
+/// six-dimensional readonly array
+pub type PyReadonlyArray6<'py, T> = PyReadonlyArray<'py, T, Ix6>;
+/// dynamic-dimensional readonly array
+pub type PyReadonlyArrayDyn<'py, T> = PyReadonlyArray<'py, T, IxDyn>;
+
+impl<'py, T: TypeNum, D: Dimension> FromPyObject<'py> for PyReadonlyArray<'py, T, D> {
+    fn extract(obj: &'py PyAny) -> PyResult<Self> {
+        let array: &PyArray<T, D> = obj.extract()?;
+        Ok(PyReadonlyArray::from(array))
+    }
+}
+
+impl<'py, T, D> IntoPy<PyObject> for PyReadonlyArray<'py, T, D> {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        let PyReadonlyArray { array, .. } = self;
+        unsafe { PyObject::from_borrowed_ptr(py, array.as_ptr()) }
+    }
+}
+
+impl<'py, T, D> From<&'py PyArray<T, D>> for PyReadonlyArray<'py, T, D> {
+    fn from(array: &'py PyArray<T, D>) -> PyReadonlyArray<'py, T, D> {
+        let flag = array.get_flag();
+        let writeable = flag & NPY_ARRAY_WRITEABLE != 0;
+        if writeable {
+            unsafe {
+                (*array.as_array_ptr()).flags &= !NPY_ARRAY_WRITEABLE;
+            }
+        }
+        Self {
+            array,
+            was_writeable: writeable,
+        }
+    }
+}
+
+impl<'py, T, D> Drop for PyReadonlyArray<'py, T, D> {
+    fn drop(&mut self) {
+        if self.was_writeable {
+            unsafe {
+                (*self.array.as_array_ptr()).flags |= NPY_ARRAY_WRITEABLE;
+            }
+        }
+    }
+}
+
+impl<'py, T, D> AsRef<PyArray<T, D>> for PyReadonlyArray<'py, T, D> {
+    fn as_ref(&self) -> &PyArray<T, D> {
+        self.array
+    }
+}
+
+impl<'py, T, D> std::ops::Deref for PyReadonlyArray<'py, T, D> {
+    type Target = PyArray<T, D>;
+    fn deref(&self) -> &PyArray<T, D> {
+        self.array
+    }
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -81,13 +81,14 @@ fn as_array() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();
     let arr = PyArray::<f64, _>::zeros(py, [3, 2, 4], false);
+    let arr = arr.readonly();
     let a = arr.as_array();
     assert_eq!(arr.shape(), a.shape());
     assert_eq!(
         arr.strides().iter().map(|x| x / 8).collect::<Vec<_>>(),
         a.strides()
     );
-    let not_contiguous = not_contiguous_array(py);
+    let not_contiguous = not_contiguous_array(py).readonly();
     assert_eq!(not_contiguous.as_array(), array![1, 3])
 }
 
@@ -95,9 +96,9 @@ fn as_array() {
 fn as_slice() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();
-    let arr = PyArray::<i32, _>::zeros(py, [3, 2, 4], false);
+    let arr = PyArray::<i32, _>::zeros(py, [3, 2, 4], false).readonly();
     assert_eq!(arr.as_slice().unwrap().len(), 3 * 2 * 4);
-    let not_contiguous = not_contiguous_array(py);
+    let not_contiguous = not_contiguous_array(py).readonly();
     assert!(not_contiguous.as_slice().is_err())
 }
 
@@ -115,7 +116,7 @@ fn from_vec2() {
     let vec2 = vec![vec![1, 2, 3]; 2];
     let gil = pyo3::Python::acquire_gil();
     let pyarray = PyArray::from_vec2(gil.python(), &vec2).unwrap();
-    assert_eq!(pyarray.as_array(), array![[1, 2, 3], [1, 2, 3]]);
+    assert_eq!(pyarray.readonly().as_array(), array![[1, 2, 3], [1, 2, 3]]);
     assert!(PyArray::from_vec2(gil.python(), &[vec![1], vec![2, 3]]).is_err());
 }
 
@@ -125,7 +126,7 @@ fn from_vec3() {
     let vec3 = vec![vec![vec![1, 2]; 2]; 2];
     let pyarray = PyArray::from_vec3(gil.python(), &vec3).unwrap();
     assert_eq!(
-        pyarray.as_array(),
+        pyarray.readonly().as_array(),
         array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]]
     );
 }
@@ -140,7 +141,7 @@ fn from_eval_to_fixed() {
         .unwrap()
         .extract()
         .unwrap();
-    assert_eq!(pyarray.as_array(), array![1, 2, 3]);
+    assert_eq!(pyarray.readonly().as_array(), array![1, 2, 3]);
 }
 
 #[test]
@@ -157,7 +158,10 @@ fn from_eval_to_dyn() {
         .unwrap()
         .extract()
         .unwrap();
-    assert_eq!(pyarray.as_array(), array![[1, 2], [3, 4]].into_dyn());
+    assert_eq!(
+        pyarray.readonly().as_array(),
+        array![[1, 2], [3, 4]].into_dyn()
+    );
 }
 
 #[test]
@@ -174,7 +178,10 @@ fn from_eval_to_dyn_u64() {
         .unwrap()
         .extract()
         .unwrap();
-    assert_eq!(pyarray.as_array(), array![[1, 2], [3, 4]].into_dyn());
+    assert_eq!(
+        pyarray.readonly().as_array(),
+        array![[1, 2], [3, 4]].into_dyn()
+    );
 }
 
 #[test]
@@ -211,5 +218,5 @@ fn array_cast() {
     let vec2 = vec![vec![1.0, 2.0, 3.0]; 2];
     let arr_f64 = PyArray::from_vec2(gil.python(), &vec2).unwrap();
     let arr_i32: &PyArray2<i32> = arr_f64.cast(false).unwrap();
-    assert_eq!(arr_i32.as_array(), array![[1, 2, 3], [1, 2, 3]]);
+    assert_eq!(arr_i32.readonly().as_array(), array![[1, 2, 3], [1, 2, 3]]);
 }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -6,7 +6,7 @@ fn to_pyarray_vec() {
     let gil = pyo3::Python::acquire_gil();
 
     let a = vec![1, 2, 3];
-    let arr = a.to_pyarray(gil.python());
+    let arr = a.to_pyarray(gil.python()).readonly();
     println!("arr.shape = {:?}", arr.shape());
     assert_eq!(arr.shape(), [3]);
     assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
@@ -31,7 +31,7 @@ fn to_pyarray_array() {
 #[test]
 fn iter_to_pyarray() {
     let gil = pyo3::Python::acquire_gil();
-    let arr = PyArray::from_iter(gil.python(), (0..10).map(|x| x * x));
+    let arr = PyArray::from_iter(gil.python(), (0..10).map(|x| x * x)).readonly();
     assert_eq!(
         arr.as_slice().unwrap(),
         &[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
@@ -41,7 +41,7 @@ fn iter_to_pyarray() {
 #[test]
 fn long_iter_to_pyarray() {
     let gil = pyo3::Python::acquire_gil();
-    let arr = PyArray::from_iter(gil.python(), (0u32..512).map(|x| x));
+    let arr = PyArray::from_iter(gil.python(), (0u32..512).map(|x| x)).readonly();
     let slice = arr.as_slice().unwrap();
     for (i, &elem) in slice.iter().enumerate() {
         assert_eq!(i as u32, elem);
@@ -55,7 +55,7 @@ macro_rules! small_array_test {
             let gil = pyo3::Python::acquire_gil();
             $({
                 let array: [$t; 2] = [$t::min_value(), $t::max_value()];
-                let pyarray = array.to_pyarray(gil.python());
+                let pyarray = array.to_pyarray(gil.python()).readonly();
                 assert_eq!(
                     pyarray.as_slice().unwrap(),
                     &[$t::min_value(), $t::max_value()]
@@ -86,7 +86,7 @@ fn usize_dtype() {
 fn into_pyarray_vec() {
     let gil = pyo3::Python::acquire_gil();
     let a = vec![1, 2, 3];
-    let arr = a.into_pyarray(gil.python());
+    let arr = a.into_pyarray(gil.python()).readonly();
     assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
 }
 
@@ -116,7 +116,10 @@ fn forder_to_pyarray() {
     let matrix = Array2::from_shape_vec([4, 2], vec![0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
     let fortran_matrix = matrix.reversed_axes();
     let fmat_py = fortran_matrix.to_pyarray(py);
-    assert_eq!(fmat_py.as_array(), array![[0, 2, 4, 6], [1, 3, 5, 7]],);
+    assert_eq!(
+        fmat_py.readonly().as_array(),
+        array![[0, 2, 4, 6], [1, 3, 5, 7]],
+    );
     pyo3::py_run!(py, fmat_py, "assert fmat_py.flags['F_CONTIGUOUS']")
 }
 
@@ -127,7 +130,10 @@ fn slice_to_pyarray() {
     let matrix = Array2::from_shape_vec([4, 2], vec![0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
     let slice = matrix.slice(s![1..4; -1, ..]);
     let slice_py = slice.to_pyarray(py);
-    assert_eq!(slice_py.as_array(), array![[6, 7], [4, 5], [2, 3]],);
+    assert_eq!(
+        slice_py.readonly().as_array(),
+        array![[6, 7], [4, 5], [2, 3]],
+    );
     pyo3::py_run!(py, slice_py, "assert slice_py.flags['C_CONTIGUOUS']")
 }
 
@@ -138,6 +144,9 @@ fn forder_into_pyarray() {
     let matrix = Array2::from_shape_vec([4, 2], vec![0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
     let fortran_matrix = matrix.reversed_axes();
     let fmat_py = fortran_matrix.into_pyarray(py);
-    assert_eq!(fmat_py.as_array(), array![[0, 2, 4, 6], [1, 3, 5, 7]],);
+    assert_eq!(
+        fmat_py.readonly().as_array(),
+        array![[0, 2, 4, 6], [1, 3, 5, 7]],
+    );
     pyo3::py_run!(py, fmat_py, "assert fmat_py.flags['F_CONTIGUOUS']")
 }


### PR DESCRIPTION
Fixes #99 and #107.
This PR makes `as_slice`, `as_slice_mut`, `as_array` and `as_array_mut` unsafe and introduces `as_cell_slice` and `PyReadonlyArray`.
We can safely use `PyReadonlyArray::as_array` like:
```rust
    #[pyfn(m, "axpy")]
    fn axpy_py<'py>(
        py: Python<'py>,
        a: f64,
        x: PyReadonlyArrayDyn<f64>,
        y: PyReadonlyArrayDyn<f64>,
    ) -> &'py PyArrayDyn<f64> {
        let x = x.as_array();
        let y = y.as_array();
        axpy(a, x, y).into_pyarray(py)
    }
```
.

The trick behind this readonly array is quite simple: disabling the writeable flag when constructing, and recovering the original flag when dropping.