### PR TITLE
Refactor Element trait 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
   - `PyArray::as_slice`, `PyArray::as_slice_mut`, `PyArray::as_array`, and `PyArray::as_array_mut` is now unsafe.
   - Introduce `PyArray::as_cell_slice`, `PyArray::to_vec`, and `PyArray::to_owned_array`
   - Rename `TypeNum` trait `Element`, and `NpyDataType` `DataType`
-  - Enables `PyArray<PyObject>`
 
 - v0.9.0
   - Update PyO3 to 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   - Remove `ErrorKind` and introduce some concrete error types
   - `PyArray::as_slice`, `PyArray::as_slice_mut`, `PyArray::as_array`, and `PyArray::as_array_mut` is now unsafe.
   - Introduce `PyArray::as_cell_slice`, `PyArray::to_vec`, and `PyArray::to_owned_array`
+  - Rename `TypeNum` trait `Element`, and `NpyDataType` `DataType`
+  - Enables `PyArray<PyObject>`
 
 - v0.9.0
   - Update PyO3 to 0.10.0

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 //! Defines error types.
-use crate::types::NpyDataType;
+use crate::types::DataType;
 use pyo3::{exceptions as exc, PyErr, PyErrArguments, PyErrValue, PyObject, Python, ToPyObject};
 use std::fmt;
 
@@ -9,15 +9,17 @@ use std::fmt;
 #[derive(Debug)]
 pub(crate) struct ArrayDim {
     dim: Option<usize>,
-    dtype: NpyDataType,
+    dtype: Option<DataType>,
 }
 
 impl fmt::Display for ArrayDim {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(d) = self.dim {
-            write!(f, "dim={:?}, dtype={:?}", d, self.dtype)
-        } else {
-            write!(f, "dim=_, dtype={:?}", self.dtype)
+        let ArrayDim { dim, dtype } = self;
+        match (dim, dtype) {
+            (Some(dim), Some(dtype)) => write!(f, "dim={:?}, dtype={:?}", dim, dtype),
+            (None, Some(dtype)) => write!(f, "dim=_, dtype={:?}", dtype),
+            (Some(dim), None) => write!(f, "dim={:?}, dtype=Unknown", dim),
+            (None, None) => write!(f, "dim=_, dtype=Unknown"),
         }
     }
 }
@@ -33,17 +35,17 @@ impl ShapeError {
     pub(crate) fn new(
         from_type: i32,
         from_dim: usize,
-        to_type: NpyDataType,
+        to_type: DataType,
         to_dim: Option<usize>,
     ) -> Self {
         ShapeError {
             from: ArrayDim {
                 dim: Some(from_dim),
-                dtype: NpyDataType::from_i32(from_type),
+                dtype: DataType::from_i32(from_type),
             },
             to: ArrayDim {
                 dim: to_dim,
-                dtype: to_type,
+                dtype: Some(to_type),
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod error;
 pub mod npyffi;
 mod readonly;
 mod slice_box;
-pub mod types;
+mod types;
 
 pub use crate::array::{
     get_array_module, PyArray, PyArray1, PyArray2, PyArray3, PyArray4, PyArray5, PyArray6,
@@ -55,7 +55,7 @@ pub use crate::readonly::{
     PyReadonlyArray, PyReadonlyArray1, PyReadonlyArray2, PyReadonlyArray3, PyReadonlyArray4,
     PyReadonlyArray5, PyReadonlyArray6, PyReadonlyArrayDyn,
 };
-pub use crate::types::{c32, c64, NpyDataType, TypeNum};
+pub use crate::types::{c32, c64, DataType, Element};
 pub use ndarray::{Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 
 /// Test readme

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -211,7 +211,7 @@ impl PyArrayAPI {
     impl_api![194; PyArray_RegisterCanCast(descr: *mut PyArray_Descr, totype: c_int, scalar: NPY_SCALARKIND) -> c_int];
     impl_api![195; PyArray_InitArrFuncs(f: *mut PyArray_ArrFuncs)];
     impl_api![196; PyArray_IntTupleFromIntp(len: c_int, vals: *mut npy_intp) -> *mut PyObject];
-    impl_api![197; PyArray_TypeNumFromName(str: *mut c_char) -> c_int];
+    impl_api![197; PyArray_ElementFromName(str: *mut c_char) -> c_int];
     impl_api![198; PyArray_ClipmodeConverter(object: *mut PyObject, val: *mut NPY_CLIPMODE) -> c_int];
     impl_api![199; PyArray_OutputConverter(object: *mut PyObject, address: *mut *mut PyArrayObject) -> c_int];
     impl_api![200; PyArray_BroadcastToShape(obj: *mut PyObject, dims: *mut npy_intp, nd: c_int) -> *mut PyObject];

--- a/src/readonly.rs
+++ b/src/readonly.rs
@@ -1,6 +1,6 @@
 //! Readonly arrays
 use crate::npyffi::NPY_ARRAY_WRITEABLE;
-use crate::{NotContiguousError, PyArray, TypeNum};
+use crate::{Element, NotContiguousError, PyArray};
 use ndarray::{ArrayView, Dimension, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 use pyo3::{prelude::*, types::PyAny, AsPyPointer};
 
@@ -52,7 +52,7 @@ pub struct PyReadonlyArray<'py, T, D> {
     was_writeable: bool,
 }
 
-impl<'py, T: TypeNum, D: Dimension> PyReadonlyArray<'py, T, D> {
+impl<'py, T: Element, D: Dimension> PyReadonlyArray<'py, T, D> {
     /// Returns the immutable view of the internal data of `PyArray` as slice.
     ///
     /// Returns `ErrorKind::NotContiguous` if the internal array is not contiguous.
@@ -110,7 +110,7 @@ pub type PyReadonlyArray6<'py, T> = PyReadonlyArray<'py, T, Ix6>;
 /// dynamic-dimensional readonly array
 pub type PyReadonlyArrayDyn<'py, T> = PyReadonlyArray<'py, T, IxDyn>;
 
-impl<'py, T: TypeNum, D: Dimension> FromPyObject<'py> for PyReadonlyArray<'py, T, D> {
+impl<'py, T: Element, D: Dimension> FromPyObject<'py> for PyReadonlyArray<'py, T, D> {
     fn extract(obj: &'py PyAny) -> PyResult<Self> {
         let array: &PyArray<T, D> = obj.extract()?;
         Ok(PyReadonlyArray::from(array))

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@ use super::npyffi::NPY_TYPES;
 ///
 /// This type is mainly for displaying error, and user don't have to use it directly.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum NpyDataType {
+pub enum DataType {
     Bool,
     Int8,
     Int16,
@@ -24,104 +24,127 @@ pub enum NpyDataType {
     Float64,
     Complex32,
     Complex64,
-    Unsupported,
+    Object,
 }
 
-impl NpyDataType {
-    pub(crate) fn from_i32(npy_t: i32) -> Self {
-        match npy_t {
-            x if x == NPY_TYPES::NPY_BOOL as i32 => NpyDataType::Bool,
-            x if x == NPY_TYPES::NPY_BYTE as i32 => NpyDataType::Int8,
-            x if x == NPY_TYPES::NPY_SHORT as i32 => NpyDataType::Int16,
-            x if x == NPY_TYPES::NPY_INT as i32 => NpyDataType::Int32,
-            x if x == NPY_TYPES::NPY_LONG as i32 => NpyDataType::from_clong(false),
-            x if x == NPY_TYPES::NPY_LONGLONG as i32 => NpyDataType::Int64,
-            x if x == NPY_TYPES::NPY_UBYTE as i32 => NpyDataType::Uint8,
-            x if x == NPY_TYPES::NPY_USHORT as i32 => NpyDataType::Uint16,
-            x if x == NPY_TYPES::NPY_UINT as i32 => NpyDataType::Uint32,
-            x if x == NPY_TYPES::NPY_ULONG as i32 => NpyDataType::from_clong(true),
-            x if x == NPY_TYPES::NPY_ULONGLONG as i32 => NpyDataType::Uint64,
-            x if x == NPY_TYPES::NPY_FLOAT as i32 => NpyDataType::Float32,
-            x if x == NPY_TYPES::NPY_DOUBLE as i32 => NpyDataType::Float64,
-            x if x == NPY_TYPES::NPY_CFLOAT as i32 => NpyDataType::Complex32,
-            x if x == NPY_TYPES::NPY_CDOUBLE as i32 => NpyDataType::Complex64,
-            _ => NpyDataType::Unsupported,
-        }
+impl DataType {
+    pub(crate) fn from_i32(npy_t: i32) -> Option<Self> {
+        Some(match npy_t {
+            x if x == NPY_TYPES::NPY_BOOL as i32 => DataType::Bool,
+            x if x == NPY_TYPES::NPY_BYTE as i32 => DataType::Int8,
+            x if x == NPY_TYPES::NPY_SHORT as i32 => DataType::Int16,
+            x if x == NPY_TYPES::NPY_INT as i32 => DataType::Int32,
+            x if x == NPY_TYPES::NPY_LONG as i32 => return DataType::from_clong(false),
+            x if x == NPY_TYPES::NPY_LONGLONG as i32 => DataType::Int64,
+            x if x == NPY_TYPES::NPY_UBYTE as i32 => DataType::Uint8,
+            x if x == NPY_TYPES::NPY_USHORT as i32 => DataType::Uint16,
+            x if x == NPY_TYPES::NPY_UINT as i32 => DataType::Uint32,
+            x if x == NPY_TYPES::NPY_ULONG as i32 => return DataType::from_clong(true),
+            x if x == NPY_TYPES::NPY_ULONGLONG as i32 => DataType::Uint64,
+            x if x == NPY_TYPES::NPY_FLOAT as i32 => DataType::Float32,
+            x if x == NPY_TYPES::NPY_DOUBLE as i32 => DataType::Float64,
+            x if x == NPY_TYPES::NPY_CFLOAT as i32 => DataType::Complex32,
+            x if x == NPY_TYPES::NPY_CDOUBLE as i32 => DataType::Complex64,
+            x if x == NPY_TYPES::NPY_OBJECT as i32 => DataType::Object,
+            _ => return None,
+        })
     }
     #[inline(always)]
-    fn from_clong(is_usize: bool) -> NpyDataType {
+    fn from_clong(is_usize: bool) -> Option<Self> {
         if cfg!(any(target_pointer_width = "32", windows)) {
-            if is_usize {
-                NpyDataType::Uint32
+            Some(if is_usize {
+                DataType::Uint32
             } else {
-                NpyDataType::Int32
-            }
+                DataType::Int32
+            })
         } else if cfg!(all(target_pointer_width = "64", not(windows))) {
-            if is_usize {
-                NpyDataType::Uint64
+            Some(if is_usize {
+                DataType::Uint64
             } else {
-                NpyDataType::Int64
-            }
+                DataType::Int64
+            })
         } else {
-            NpyDataType::Unsupported
+            None
+        }
+    }
+    pub fn into_ffi_dtype(self) -> NPY_TYPES {
+        match self {
+            DataType::Bool => NPY_TYPES::NPY_BOOL,
+            DataType::Int8 => NPY_TYPES::NPY_BYTE,
+            DataType::Int16 => NPY_TYPES::NPY_SHORT,
+            DataType::Int32 => NPY_TYPES::NPY_INT,
+            DataType::Int64 => NPY_TYPES::NPY_LONGLONG,
+            DataType::Uint8 => NPY_TYPES::NPY_UBYTE,
+            DataType::Uint16 => NPY_TYPES::NPY_USHORT,
+            DataType::Uint32 => NPY_TYPES::NPY_UINT,
+            DataType::Uint64 => NPY_TYPES::NPY_ULONGLONG,
+            DataType::Float32 => NPY_TYPES::NPY_FLOAT,
+            DataType::Float64 => NPY_TYPES::NPY_DOUBLE,
+            DataType::Complex32 => NPY_TYPES::NPY_CFLOAT,
+            DataType::Complex64 => NPY_TYPES::NPY_CDOUBLE,
+            DataType::Object => NPY_TYPES::NPY_OBJECT,
         }
     }
 }
 
-pub trait TypeNum: std::fmt::Debug + Copy {
+/// Represents that a type can be an element of `PyArray`.
+pub trait Element: Clone {
+    const DATA_TYPE: DataType;
     fn is_same_type(other: i32) -> bool;
-    fn npy_data_type() -> NpyDataType;
-    fn typenum_default() -> i32;
+    fn ffi_dtype() -> NPY_TYPES {
+        Self::DATA_TYPE.into_ffi_dtype()
+    }
 }
 
-macro_rules! impl_type_num {
+macro_rules! impl_num_element {
     ($t:ty, $npy_dat_t:ident $(,$npy_types: ident)+) => {
-        impl TypeNum for $t {
+        impl Element for $t {
+            const DATA_TYPE: DataType = DataType::$npy_dat_t;
             fn is_same_type(other: i32) -> bool {
                 $(other == NPY_TYPES::$npy_types as i32 ||)+ false
-            }
-            fn npy_data_type() -> NpyDataType {
-                NpyDataType::$npy_dat_t
-            }
-            fn typenum_default() -> i32 {
-                let t = ($(NPY_TYPES::$npy_types, )+);
-                t.0 as i32
             }
         }
     };
 }
 
-impl_type_num!(bool, Bool, NPY_BOOL);
-impl_type_num!(i8, Int8, NPY_BYTE);
-impl_type_num!(i16, Int16, NPY_SHORT);
-impl_type_num!(u8, Uint8, NPY_UBYTE);
-impl_type_num!(u16, Uint16, NPY_USHORT);
-impl_type_num!(f32, Float32, NPY_FLOAT);
-impl_type_num!(f64, Float64, NPY_DOUBLE);
-impl_type_num!(c32, Complex32, NPY_CFLOAT);
-impl_type_num!(c64, Complex64, NPY_CDOUBLE);
+impl_num_element!(bool, Bool, NPY_BOOL);
+impl_num_element!(i8, Int8, NPY_BYTE);
+impl_num_element!(i16, Int16, NPY_SHORT);
+impl_num_element!(u8, Uint8, NPY_UBYTE);
+impl_num_element!(u16, Uint16, NPY_USHORT);
+impl_num_element!(f32, Float32, NPY_FLOAT);
+impl_num_element!(f64, Float64, NPY_DOUBLE);
+impl_num_element!(c32, Complex32, NPY_CFLOAT);
+impl_num_element!(c64, Complex64, NPY_CDOUBLE);
 
 cfg_if! {
     if #[cfg(all(target_pointer_width = "64", windows))] {
-            impl_type_num!(usize, Uint64, NPY_ULONGLONG);
+            impl_num_element!(usize, Uint64, NPY_ULONGLONG);
     } else if #[cfg(all(target_pointer_width = "64", not(windows)))] {
-            impl_type_num!(usize, Uint64, NPY_ULONG, NPY_ULONGLONG);
+            impl_num_element!(usize, Uint64, NPY_ULONG, NPY_ULONGLONG);
     } else if #[cfg(all(target_pointer_width = "32", windows))] {
-            impl_type_num!(usize, Uint32, NPY_UINT, NPY_ULONG);
+            impl_num_element!(usize, Uint32, NPY_UINT, NPY_ULONG);
     } else if #[cfg(all(target_pointer_width = "32", not(windows)))] {
-            impl_type_num!(usize, Uint32, NPY_UINT);
+            impl_num_element!(usize, Uint32, NPY_UINT);
     }
 }
 cfg_if! {
     if #[cfg(any(target_pointer_width = "32", windows))] {
-        impl_type_num!(i32, Int32, NPY_INT, NPY_LONG);
-        impl_type_num!(u32, Uint32, NPY_UINT, NPY_ULONG);
-        impl_type_num!(i64, Int64, NPY_LONGLONG);
-        impl_type_num!(u64, Uint64, NPY_ULONGLONG);
+        impl_num_element!(i32, Int32, NPY_INT, NPY_LONG);
+        impl_num_element!(u32, Uint32, NPY_UINT, NPY_ULONG);
+        impl_num_element!(i64, Int64, NPY_LONGLONG);
+        impl_num_element!(u64, Uint64, NPY_ULONGLONG);
     } else if #[cfg(all(target_pointer_width = "64", not(windows)))] {
-        impl_type_num!(i32, Int32, NPY_INT);
-        impl_type_num!(u32, Uint32, NPY_UINT);
-        impl_type_num!(i64, Int64, NPY_LONG, NPY_LONGLONG);
-        impl_type_num!(u64, Uint64, NPY_ULONG, NPY_ULONGLONG);
+        impl_num_element!(i32, Int32, NPY_INT);
+        impl_num_element!(u32, Uint32, NPY_UINT);
+        impl_num_element!(i64, Int64, NPY_LONG, NPY_LONGLONG);
+        impl_num_element!(u64, Uint64, NPY_ULONG, NPY_ULONGLONG);
+    }
+}
+
+impl Element for pyo3::PyObject {
+    const DATA_TYPE: DataType = DataType::Object;
+    fn is_same_type(other: i32) -> bool {
+        other == Self::DATA_TYPE as i32
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,6 +67,7 @@ impl DataType {
             None
         }
     }
+    #[inline]
     pub fn into_ffi_dtype(self) -> NPY_TYPES {
         match self {
             DataType::Bool => NPY_TYPES::NPY_BOOL,
@@ -91,6 +92,7 @@ impl DataType {
 pub trait Element: Clone {
     const DATA_TYPE: DataType;
     fn is_same_type(other: i32) -> bool;
+    #[inline]
     fn ffi_dtype() -> NPY_TYPES {
         Self::DATA_TYPE.into_ffi_dtype()
     }
@@ -139,12 +141,5 @@ cfg_if! {
         impl_num_element!(u32, Uint32, NPY_UINT);
         impl_num_element!(i64, Int64, NPY_LONG, NPY_LONGLONG);
         impl_num_element!(u64, Uint64, NPY_ULONG, NPY_ULONGLONG);
-    }
-}
-
-impl Element for pyo3::PyObject {
-    const DATA_TYPE: DataType = DataType::Object;
-    fn is_same_type(other: i32) -> bool {
-        other == Self::DATA_TYPE as i32
     }
 }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -13,6 +13,23 @@ fn to_pyarray_vec() {
 }
 
 #[test]
+fn to_pyarray_object_vec() {
+    use pyo3::{AsPyRef, ToPyObject};
+    let gil = pyo3::Python::acquire_gil();
+    let py = gil.python();
+    let dict = pyo3::types::PyDict::new(py);
+    let list = pyo3::types::PyString::new(py, "Hello:)");
+    let a = vec![dict.to_object(py), list.to_object(py)];
+    let arr = a.to_pyarray(gil.python()).readonly();
+    for (a, b) in a.iter().zip(arr.as_slice().unwrap().iter()) {
+        assert_eq!(
+            a.as_ref(py).compare(b).map_err(|e| e.print(py)).unwrap(),
+            std::cmp::Ordering::Equal
+        );
+    }
+}
+
+#[test]
 fn to_pyarray_array() {
     let gil = pyo3::Python::acquire_gil();
 

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -13,23 +13,6 @@ fn to_pyarray_vec() {
 }
 
 #[test]
-fn to_pyarray_object_vec() {
-    use pyo3::{AsPyRef, ToPyObject};
-    let gil = pyo3::Python::acquire_gil();
-    let py = gil.python();
-    let dict = pyo3::types::PyDict::new(py);
-    let list = pyo3::types::PyString::new(py, "Hello:)");
-    let a = vec![dict.to_object(py), list.to_object(py)];
-    let arr = a.to_pyarray(gil.python()).readonly();
-    for (a, b) in a.iter().zip(arr.as_slice().unwrap().iter()) {
-        assert_eq!(
-            a.as_ref(py).compare(b).map_err(|e| e.print(py)).unwrap(),
-            std::cmp::Ordering::Equal
-        );
-    }
-}
-
-#[test]
 fn to_pyarray_array() {
     let gil = pyo3::Python::acquire_gil();
 


### PR DESCRIPTION
I hope this to be the last step to 0.10.0.
`TypeNum` trait is refactored as `Element`, and ~`PyArray<PyObject>` is allowed again.~