### PR TITLE
Introduce PyReadonlyArray::get and Make PyArray::get unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
+- Unreleased
+  - `PyArray::get` is now unsafe.
+  - Introduce `PyArray::get_owned` and `PyReadonlyArray::get`.
+
 - v0.10.0
-  - Remove `ErrorKind` and introduce some concrete error types
+  - Remove `ErrorKind` and introduce some concrete error types.
   - `PyArray::as_slice`, `PyArray::as_slice_mut`, `PyArray::as_array`, and `PyArray::as_array_mut` is now unsafe.
-  - Introduce `PyArray::as_cell_slice`, `PyArray::to_vec`, and `PyArray::to_owned_array`
-  - Rename `TypeNum` trait `Element`, and `NpyDataType` `DataType`
+  - Introduce `PyArray::as_cell_slice`, `PyArray::to_vec`, and `PyArray::to_owned_array`.
+  - Rename `TypeNum` trait `Element`, and `NpyDataType` `DataType`.
 
 - v0.9.0
   - Update PyO3 to 0.10.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::missing_safety_doc, clippy::too_many_arguments)] // FIXME
+#![allow(clippy::missing_safety_doc)] // FIXME
 
 //! `rust-numpy` provides Rust interfaces for [NumPy C APIs](https://numpy.org/doc/stable/reference/c-api),
 //! especially for [ndarray](https://numpy.org/doc/stable/reference/arrays.ndarray.html) class.

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -1,7 +1,7 @@
 //! Low-Level bindings for NumPy C API.
 //!
 //! https://numpy.org/doc/stable/reference/c-api
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, clippy::too_many_arguments)]
 
 use pyo3::{ffi, Python};
 use std::ffi::CString;


### PR DESCRIPTION
It's unsafe for the same reason as `as_slice`.
Originally pointed out by @tanriol in [the comment](https://github.com/PyO3/rust-numpy/pull/140#issuecomment-659278530), thanks!