### PR TITLE
Update to pyo3 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
 ndarray = ">=0.13"
-pyo3 = { git = "https://github.com/PyO3/pyo3" }
+pyo3 = "0.12.0"
 
 [features]
 # In default setting, python version is automatically detected

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
 ndarray = ">=0.13"
-pyo3 = "0.11.1"
+pyo3 = { git = "https://github.com/PyO3/pyo3" }
 
 [features]
 # In default setting, python version is automatically detected

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -14,5 +14,5 @@ ndarray = ">= 0.13"
 ndarray-linalg = { version = "0.12", features = ["openblas"] }
 
 [dependencies.pyo3]
-version = "0.11.1"
+version = "0.12.0"
 features = ["extension-module"]

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -13,5 +13,5 @@ numpy = { path = "../.." }
 ndarray = ">= 0.12"
 
 [dependencies.pyo3]
-version = "0.11.1"
+version = "0.12.0"
 features = ["extension-module"]

--- a/src/array.rs
+++ b/src/array.rs
@@ -75,7 +75,6 @@ use crate::types::Element;
 ///     array![[8., 15.], [12., 23.]]
 /// );
 /// ```
-#[derive(Debug)]
 pub struct PyArray<T, D>(PyAny, PhantomData<T>, PhantomData<D>);
 
 /// One-dimensional array.
@@ -111,6 +110,7 @@ pyobject_native_type_convert!(
 );
 
 pyobject_native_type_named!(PyArray<T, D>, T, D);
+pyobject_native_type_fmt!(PyArray<T, D>, T, D);
 
 impl<'a, T, D> std::convert::From<&'a PyArray<T, D>> for &'a PyAny {
     fn from(ob: &'a PyArray<T, D>) -> Self {

--- a/src/array.rs
+++ b/src/array.rs
@@ -132,7 +132,7 @@ impl<'a, T: Element, D: Dimension> FromPyObject<'a> for &'a PyArray<T, D> {
     fn extract(ob: &'a PyAny) -> PyResult<Self> {
         let array = unsafe {
             if npyffi::PyArray_Check(ob.as_ptr()) == 0 {
-                return Err(PyDowncastError::new(ob, "Array").into());
+                return Err(PyDowncastError::new(ob, "PyArray<T, D>").into());
             }
             &*(ob as *const PyAny as *const PyArray<T, D>)
         };
@@ -207,7 +207,7 @@ impl<T, D> PyArray<T, D> {
     ///
     /// # Example
     /// ```
-    /// use pyo3::{GILGuard, Python, Py, AsPyRef};
+    /// use pyo3::{GILGuard, Python, Py};
     /// use numpy::PyArray1;
     /// fn return_py_array() -> Py<PyArray1<i32>> {
     ///    let gil = Python::acquire_gil();

--- a/src/array.rs
+++ b/src/array.rs
@@ -75,6 +75,7 @@ use crate::types::Element;
 ///     array![[8., 15.], [12., 23.]]
 /// );
 /// ```
+#[derive(Debug)]
 pub struct PyArray<T, D>(PyAny, PhantomData<T>, PhantomData<D>);
 
 /// One-dimensional array.
@@ -131,7 +132,7 @@ impl<'a, T: Element, D: Dimension> FromPyObject<'a> for &'a PyArray<T, D> {
     fn extract(ob: &'a PyAny) -> PyResult<Self> {
         let array = unsafe {
             if npyffi::PyArray_Check(ob.as_ptr()) == 0 {
-                return Err(PyDowncastError.into());
+                return Err(PyDowncastError::new(ob, "Array").into());
             }
             &*(ob as *const PyAny as *const PyArray<T, D>)
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ macro_rules! impl_pyerr {
 
         impl std::convert::From<$err_type> for PyErr {
             fn from(err: $err_type) -> PyErr {
-                PyErr::from_value::<exc::TypeError>(PyErrValue::from_err_args(err))
+                PyErr::from_value::<exc::PyTypeError>(PyErrValue::from_err_args(err))
             }
         }
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Defines error types.
 use crate::types::DataType;
-use pyo3::{exceptions as exc, PyErr, PyErrArguments, PyErrValue, PyObject, Python, ToPyObject};
+use pyo3::{exceptions as exc, PyErr, PyErrArguments, PyObject, Python, ToPyObject};
 use std::fmt;
 
 /// Represents a dimension and dtype of numpy array.
@@ -63,14 +63,14 @@ macro_rules! impl_pyerr {
         impl std::error::Error for $err_type {}
 
         impl PyErrArguments for $err_type {
-            fn arguments(&self, py: Python) -> PyObject {
+            fn arguments(self, py: Python) -> PyObject {
                 format!("{}", self).to_object(py)
             }
         }
 
         impl std::convert::From<$err_type> for PyErr {
             fn from(err: $err_type) -> PyErr {
-                PyErr::from_value::<exc::PyTypeError>(PyErrValue::from_err_args(err))
+                exc::PyTypeError::new_err(err)
             }
         }
     };

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -42,9 +42,10 @@ impl PyArrayAPI {
     }
     fn get(&self, offset: isize) -> *const *const c_void {
         if self.api.get().is_null() {
-            let ensure_gil = pyo3::internal_utils::ensure_gil();
-            let api = get_numpy_api(unsafe { ensure_gil.python() }, MOD_NAME, CAPSULE_NAME);
-            self.api.set(api);
+            Python::with_gil(|py| {
+                let api = get_numpy_api(py, MOD_NAME, CAPSULE_NAME);
+                self.api.set(api);
+            });
         }
         unsafe { self.api.get().offset(offset) }
     }

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -4,6 +4,7 @@ use std::os::raw::*;
 use std::{cell::Cell, ptr};
 
 use pyo3::ffi::PyObject;
+use pyo3::Python;
 
 use super::get_numpy_api;
 use super::objects::*;
@@ -28,9 +29,10 @@ impl PyUFuncAPI {
     }
     fn get(&self, offset: isize) -> *const *const c_void {
         if self.api.get().is_null() {
-            let ensure_gil = pyo3::internal_utils::ensure_gil();
-            let api = get_numpy_api(unsafe { ensure_gil.python() }, MOD_NAME, CAPSULE_NAME);
-            self.api.set(api);
+            Python::with_gil(|py| {
+                let api = get_numpy_api(py, MOD_NAME, CAPSULE_NAME);
+                self.api.set(api);
+            });
         }
         unsafe { self.api.get().offset(offset) }
     }


### PR DESCRIPTION
I tried using the current pyo3 master branch but ran into problems.

This is the current error which I guess stems from the changes to `PyDowncastError`.

```
   --> src/array.rs:134:28
    |
134 |                 return Err(PyDowncastError.into());
    |                            ^^^^^^^^^^^^^^^-----
    |                            |
    |                            help: use the path separator to refer to an item: `PyDowncastError::into`
```