### PR TITLE
Release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- v0.12.2
+  - Pin PyO3 minor versions to 0.12
+  - Pin ndarray minor versions to 0.13
+
 - v0.12.1
   - Fix compile error in Rust 1.39
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>", "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>"]
 description = "Rust binding of NumPy C-API"
 documentation = "https://pyo3.github.io/rust-numpy/numpy"
@@ -14,8 +14,8 @@ cfg-if = "0.1"
 libc = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
-ndarray = ">=0.13"
-pyo3 = ">=0.12"
+ndarray = "0.13"
+pyo3 = "0.12"
 
 [features]
 # In default setting, python version is automatically detected

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
-ndarray = ">= 0.13"
+ndarray = "0.13"
 ndarray-linalg = { version = "0.12", features = ["openblas"] }
 
 [dependencies.pyo3]

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
-ndarray = ">= 0.12"
+ndarray = "0.13"
 
 [dependencies.pyo3]
 version = "0.12"


### PR DESCRIPTION
Unfortunately releasing PyO3 0.13 has broken `rust-numpy` 0.12 versions because the Cargo.toml is too flexible.

I think we should release `rust-numpy` version 0.12.2 with a restricted version to fix the issue for users who need to continue with rust-numpy 0.12 for now.

Also #163 contains all the fixes needed for `rust-numpy` to work on PyO3 0.13, for an eventual `rust-numpy` 0.13.

Closes #169 