### PR TITLE
Publish with `license` field instead of `license-file`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://pyo3.github.io/rust-numpy/numpy"
 edition = "2018"
 repository = "https://github.com/rust-numpy/rust-numpy"
 keywords = ["numpy", "python", "binding"]
-license-file = "LICENSE"
+license = "BSD-2-Clause"
 
 [dependencies]
 cfg-if = "0.1"


### PR DESCRIPTION
Specifying a `license-file` field informs crates.io that this crate is
under a non-standard license[1], and it publishes the package as
such[2]. Specifying the license with the `license` field allows
crates.io to expose the actual license information, which allows this
project to be used in certain corporations with automatic license
checking. See pyo3 as an example[3][4].

[1] https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields
[2] https://crates.io/api/v1/crates/numpy/0.13.1
[3] https://crates.io/api/v1/crates/pyo3/0.13.2
[4] https://github.com/PyO3/pyo3/blob/v0.13.2/Cargo.toml#L12