### PR TITLE
Update ndarray requirement to allow 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "0.1"
 libc = "0.2"
 num-complex = ">= 0.2, <= 0.4"
 num-traits = "0.2"
-ndarray = ">= 0.13, < 0.15"
+ndarray = ">= 0.13, <= 0.15"
 pyo3 = { version = "0.13", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
0.15 has some really cool stuff like `to_shape` that I'm hoping to use, so I'd love to be able to use it with rust-numpy :)