### PR TITLE
Bump PyO3 version to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.13.2"
+version = "0.14.0"
 authors = [
     "Toshiki Teramura <toshiki.teramura@gmail.com>",
     "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>",
@@ -19,10 +19,10 @@ libc = "0.2"
 num-complex = ">= 0.2, <= 0.4"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
-pyo3 = { version = "0.13", default-features = false }
+pyo3 = { version = "0.14", default-features = false }
 
 [dev-dependencies]
-pyo3 = "0.13"
+pyo3 = { version = "0.14", features = ["auto-initialize"] }
 
 [features]
 # In default setting, python version is automatically detected

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ using [setuptools-rust](https://github.com/PyO3/setuptools-rust).
 name = "numpy-test"
 
 [dependencies]
-pyo3 = "0.13"
-numpy = "0.13"
+pyo3 = "0.14"
+numpy = "0.14"
 ```
 
 ```rust
@@ -92,11 +92,11 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-numpy = "0.13"
+numpy = "0.14"
 ndarray = "0.14"
 
 [dependencies.pyo3]
-version = "0.13"
+version = "0.14"
 features = ["extension-module"]
 ```
 

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -15,5 +15,5 @@ ndarray = "0.15"
 ndarray-linalg = { git = "https://github.com/rust-ndarray/ndarray-linalg", features = ["openblas-static"] }
 
 [dependencies.pyo3]
-version = "0.13"
+version = "0.14"
 features = ["extension-module"]

--- a/examples/linalg/pyproject.toml
+++ b/examples/linalg/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 build-backend = "maturin"
+requires = ["poetry_core>=1.0.0"]
 
 [tool.poetry]
 name = "numpy-linalg-example"

--- a/examples/linalg/src/lib.rs
+++ b/examples/linalg/src/lib.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::{pymodule, PyErr, PyModule, PyResult, Python};
 
 #[pymodule]
 fn rust_linalg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    #[pyfn(m, "inv")]
+    #[pyfn(m)]
     fn inv<'py>(py: Python<'py>, x: PyReadonlyArray2<'py, f64>) -> PyResult<&'py PyArray2<f64>> {
         let x = x
             .as_array()

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -14,5 +14,5 @@ ndarray = "0.15.2"
 num-complex = "0.4.0"
 
 [dependencies.pyo3]
-version = "0.13"
+version = "0.14"
 features = ["extension-module"]

--- a/examples/simple-extension/pyproject.toml
+++ b/examples/simple-extension/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 build-backend = "maturin"
+requires = ["poetry_core>=1.0.0"]
 
 [tool.poetry]
 name = "numpy-example"

--- a/examples/simple-extension/src/lib.rs
+++ b/examples/simple-extension/src/lib.rs
@@ -20,7 +20,8 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     }
 
     // wrapper of `axpy`
-    #[pyfn(m, "axpy")]
+    #[pyfn(m)]
+    #[pyo3(name = "axpy")]
     fn axpy_py<'py>(
         py: Python<'py>,
         a: f64,
@@ -33,14 +34,16 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     }
 
     // wrapper of `mult`
-    #[pyfn(m, "mult")]
+    #[pyfn(m)]
+    #[pyo3(name = "mult")]
     fn mult_py(a: f64, x: &PyArrayDyn<f64>) {
         let x = unsafe { x.as_array_mut() };
         mult(a, x);
     }
 
     // wrapper of `conj`
-    #[pyfn(m, "conj")]
+    #[pyfn(m)]
+    #[pyo3(name = "conj")]
     fn conj_py<'py>(py: Python<'py>, x: PyReadonlyArrayDyn<'_, c64>) -> &'py PyArrayDyn<c64> {
         conj(x.as_array()).into_pyarray(py)
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -104,10 +104,9 @@ impl<T, D> type_object::PySizedLayout<PyArray<T, D>> for npyffi::PyArrayObject {
 
 pyobject_native_type_info!(
     PyArray<T, D>,
-    npyffi::PyArrayObject,
     *npyffi::PY_ARRAY_API.get_type_object(npyffi::NpyTypes::PyArray_Type),
     Some("numpy"),
-    npyffi::PyArray_Check
+    #checkfunction=npyffi::PyArray_Check
     ; T
     ; D
 );

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -26,10 +26,9 @@ pub struct PyArrayDescr(PyAny);
 
 pyobject_native_type_core!(
     PyArrayDescr,
-    PyArray_Descr,
     *PY_ARRAY_API.get_type_object(NpyTypes::PyArrayDescr_Type),
-    Some("numpy"),
-    arraydescr_check
+    #module=Some("numpy"),
+    #checkfunction=arraydescr_check
 );
 
 unsafe fn arraydescr_check(op: *mut ffi::PyObject) -> c_int {

--- a/src/npyiter.rs
+++ b/src/npyiter.rs
@@ -51,7 +51,7 @@ pub enum NpyIterFlag {
 }
 
 impl NpyIterFlag {
-    fn to_c_enum(&self) -> npy_uint32 {
+    fn to_c_enum(self) -> npy_uint32 {
         use NpyIterFlag::*;
         match self {
             CommonDtype => NPY_ITER_COMMON_DTYPE,

--- a/src/sum_products.rs
+++ b/src/sum_products.rs
@@ -73,12 +73,10 @@ where
     DOUT: Dimension,
     T: Element,
 {
-    let subscripts: std::borrow::Cow<CStr> = if subscripts.ends_with("\0") {
-        CStr::from_bytes_with_nul(subscripts.as_bytes())
-            .unwrap()
-            .into()
-    } else {
-        std::ffi::CString::new(subscripts).unwrap().into()
+    let subscripts: std::borrow::Cow<CStr> = match CStr::from_bytes_with_nul(subscripts.as_bytes())
+    {
+        Ok(subscripts) => subscripts.into(),
+        Err(_) => std::ffi::CString::new(subscripts).unwrap().into(),
     };
     let obj = unsafe {
         let result = PY_ARRAY_API.PyArray_EinsteinSum(


### PR DESCRIPTION
This implies an API change due to re-exported types from PyO3.