### PR TITLE
Avoid raw pointers in SliceBox and make the Send bound explicit

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -422,7 +422,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     {
         let dims = dims.into_dimension();
         let container = SliceBox::new(slice);
-        let data_ptr = container.data;
+        let data_ptr = container.data.as_ptr();
         let cell = pyo3::PyClassInitializer::from(container)
             .create_cell(py)
             .expect("Object creation failed.");

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -166,7 +166,7 @@ impl DataType {
 }
 
 /// Represents that a type can be an element of `PyArray`.
-pub trait Element: Clone {
+pub trait Element: Clone + Send {
     /// `DataType` corresponding to this type.
     const DATA_TYPE: DataType;
 


### PR DESCRIPTION
This is a follow-up to #189. I think the main benefit besides removing two unsafe usages is propagating the `Send` bound which seems to imply that `Element` must indeed be `Send` to be wrapped within `SliceBox` and managed by Python.

Taking this a bit further, there seems to be nothing slice or box specific about `SliceBox`, i.e. we could just as well have a
```rust
struct Opaque<T>(pub(crate) T);
```
which does not care about its contents at all, that is besides making it possible for Python to indirectly call `T`'s `Drop` implementation.