### PR TITLE
Remove resolver argument from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 repository = "https://github.com/rust-numpy/rust-numpy"
 keywords = ["numpy", "python", "binding"]
 license = "BSD-2-Clause"
-resolver = "2"
 
 [dependencies]
 cfg-if = "0.1"


### PR DESCRIPTION
When building rust-numpy with the rust/cargo 1.48 packaged on Debian
bullseye the build fails because in Cargo 1.48 the resolver option was a
nightly only feature and Cargo errors. This feature wasn't stabilized
until 1.51. I think we aren't catching this in the MSRV jobs because
1.41 is old enough that the resolver option wasn't known.