### PR TITLE
fix typo in documentation

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -79,7 +79,7 @@ where
 
 /// Conversion trait from rust types to `PyArray`.
 ///
-/// This trait takes `&self`, which means **it alocates in Python heap and then copies
+/// This trait takes `&self`, which means **it allocates in Python heap and then copies
 /// elements there**.
 /// # Example
 /// ```


### PR DESCRIPTION
Hi thanks for the binding! I see this typo when reading doc, so I make a very small fix.