### PR TITLE
Give PyArray<PyObject> another try.

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -776,7 +776,14 @@ impl<T: Element> PyArray<T, Ix1> {
     /// });
     /// ```
     pub fn from_exact_iter(py: Python<'_>, iter: impl ExactSizeIterator<Item = T>) -> &Self {
-        let array = Self::new(py, [iter.len()], false);
+        // Use zero-initialized pointers for object arrays
+        // so that partially initialized arrays can be dropped safely
+        // in case the iterator implementation panics.
+        let array = if T::DATA_TYPE == DataType::Object {
+            Self::zeros(py, [iter.len()], false)
+        } else {
+            Self::new(py, [iter.len()], false)
+        };
         unsafe {
             for (i, item) in iter.enumerate() {
                 *array.uget_mut([i]) = item;
@@ -804,7 +811,14 @@ impl<T: Element> PyArray<T, Ix1> {
         let iter = iter.into_iter();
         let (min_len, max_len) = iter.size_hint();
         let mut capacity = max_len.unwrap_or_else(|| min_len.max(512 / mem::size_of::<T>()));
-        let array = Self::new(py, [capacity], false);
+        // Use zero-initialized pointers for object arrays
+        // so that partially initialized arrays can be dropped safely
+        // in case the iterator implementation panics.
+        let array = if T::DATA_TYPE == DataType::Object {
+            Self::zeros(py, [capacity], false)
+        } else {
+            Self::new(py, [capacity], false)
+        };
         let mut length = 0;
         unsafe {
             for (i, item) in iter.enumerate() {

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -169,3 +169,26 @@ fn forder_into_pyarray() {
         pyo3::py_run!(py, fmat_py, "assert fmat_py.flags['F_CONTIGUOUS']")
     })
 }
+
+#[test]
+fn to_pyarray_object_vec() {
+    use pyo3::{
+        types::{PyDict, PyString},
+        ToPyObject,
+    };
+    use std::cmp::Ordering;
+
+    pyo3::Python::with_gil(|py| {
+        let dict = PyDict::new(py);
+        let string = PyString::new(py, "Hello:)");
+        let vec = vec![dict.to_object(py), string.to_object(py)];
+        let arr = vec.to_pyarray(py).readonly();
+
+        for (a, b) in vec.iter().zip(arr.as_slice().unwrap().iter()) {
+            assert_eq!(
+                a.as_ref(py).compare(b).map_err(|e| e.print(py)).unwrap(),
+                Ordering::Equal
+            );
+        }
+    })
+}


### PR DESCRIPTION
I am not sure what changed since https://github.com/PyO3/rust-numpy/pull/143#issuecomment-658867164 or whether the segmentation fault was only triggered by a more involved test but this seems to work using Python 3.8.2 on Linux. (Similarly to how https://github.com/PyO3/rust-numpy/issues/138#issuecomment-962435764 worked in this environment.)

Fixes #175 