### PR TITLE
Make the PyArray::new method unsafe and document what can and cannot be done with its return value.

### DIFF
--- a/tests/array.rs
+++ b/tests/array.rs
@@ -25,7 +25,7 @@ fn not_contiguous_array<'py>(py: Python<'py>) -> &'py PyArray1<i32> {
 fn new_c_order() {
     let dim = [3, 5];
     pyo3::Python::with_gil(|py| {
-        let arr = PyArray::<f64, _>::new(py, dim, false);
+        let arr = PyArray::<f64, _>::zeros(py, dim, false);
         assert!(arr.ndim() == 2);
         assert!(arr.dims() == dim);
         let size = std::mem::size_of::<f64>() as isize;
@@ -37,7 +37,7 @@ fn new_c_order() {
 fn new_fortran_order() {
     let dim = [3, 5];
     pyo3::Python::with_gil(|py| {
-        let arr = PyArray::<f64, _>::new(py, dim, true);
+        let arr = PyArray::<f64, _>::zeros(py, dim, true);
         assert!(arr.ndim() == 2);
         assert!(arr.dims() == dim);
         let size = std::mem::size_of::<f64>() as isize;
@@ -109,7 +109,7 @@ fn as_slice() {
 #[test]
 fn is_instance() {
     pyo3::Python::with_gil(|py| {
-        let arr = PyArray2::<f64>::new(py, [3, 5], false);
+        let arr = PyArray2::<f64>::zeros(py, [3, 5], false);
         assert!(arr.is_instance::<PyArray2<f64>>().unwrap());
         assert!(!arr.is_instance::<PyList>().unwrap());
     })


### PR DESCRIPTION
Luckily, NumPy will always zero-initialize object pointers, c.f. https://github.com/numpy/numpy/blob/84e0707afa587e7655410561324ac36085db2b95/numpy/core/src/multiarray/ctors.c#L826-L835, so that even without invoking `Self::zeros`, the return values of `Self::new` will always be safe to drop.

However their elements will be invalid (null pointers are not valid instances of `PyObject` as `Py<...>` is built on `NonNull<...>`). Hence the method is marked `unsafe` as referencing its elements will invoke undefined behaviour. To actually initialise the elements, the new `uget_raw` method is provided (and used internally in `from_iter`, `from_exact_iter`, `from_vec2` and `from_vec3` where we currently invoke UB ourselves).

Fixes #217 
