### PR TITLE
Use re-export of ndarray in example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ features = ["extension-module"]
 ```
 
 ```rust
-use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
+use numpy::ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
 use numpy::{IntoPyArray, PyArrayDyn, PyReadonlyArrayDyn};
 use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
 


### PR DESCRIPTION
 It is preferred and there is no direct dependency given in the Cargo.toml.

Fixes #224 