### PR TITLE
Make Clippy stricter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
           toolchain: stable
           profile: minimal
           components: rustfmt, clippy
-      - run: |
+      - env:
+          CLIPPYFLAGS: --deny warnings --allow clippy::needless-lifetimes
+        run: |
           cargo fmt --all -- --check
-          cargo clippy --tests
-          for example in examples/*; do (cd $example/; cargo clippy) || exit 1; done
+          cargo clippy --tests -- $CLIPPYFLAGS
+          for example in examples/*; do (cd $example/; cargo clippy -- $CLIPPYFLAGS) || exit 1; done
 
   test:
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }}

--- a/src/array.rs
+++ b/src/array.rs
@@ -448,7 +448,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         ID: IntoDimension<Dim = D>,
     {
         let dims = dims.into_dimension();
-        let data_ptr = data_ptr.unwrap_or(boxed_slice.as_ptr());
+        let data_ptr = data_ptr.unwrap_or_else(|| boxed_slice.as_ptr());
         let container = SliceBox::new(boxed_slice);
         let cell = pyo3::PyClassInitializer::from(container)
             .create_cell(py)


### PR DESCRIPTION
But disable needless-lifetimes lint as we often want to make the GIL lifetime explicit.