### PR TITLE
Bump dependency on cfg-if

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.41.1
+          toolchain: 1.48.0
           default: true
       - name: Install maturin, poetry, and toml
         run: pip install maturin poetry toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
 description = "Rust binding of NumPy C-API"
 documentation = "https://pyo3.github.io/rust-numpy/numpy"
 edition = "2018"
+rust-version = "1.48"
 repository = "https://github.com/PyO3/rust-numpy"
 keywords = ["numpy", "python", "binding"]
 license = "BSD-2-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["numpy", "python", "binding"]
 license = "BSD-2-Clause"
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "1.0"
 libc = "0.2"
 num-complex = ">= 0.2, <= 0.4"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ rust-numpy
 ===========
 [![Actions Status](https://github.com/PyO3/rust-numpy/workflows/CI/badge.svg)](https://github.com/PyO3/rust-numpy/actions)
 [![Crate](https://img.shields.io/crates/v/numpy.svg)](https://crates.io/crates/numpy)
-[![Minimum rustc 1.41](https://img.shields.io/badge/rustc-1.41+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Minimum rustc 1.48](https://img.shields.io/badge/rustc-1.48+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 
 Rust bindings for the NumPy C-API.
 
@@ -12,7 +12,7 @@ Rust bindings for the NumPy C-API.
 
 
 ## Requirements
-- Rust >= 1.41.1
+- Rust >= 1.48.0
   - Basically, our MSRV follows the one of [PyO3](https://github.com/PyO3/pyo3)
 - Python >= 3.6
   - Python 3.5 support is dropped from 0.13

--- a/src/array.rs
+++ b/src/array.rs
@@ -3,8 +3,8 @@ use crate::npyffi::{self, npy_intp, NPY_ORDER, PY_ARRAY_API};
 use ndarray::*;
 use num_traits::AsPrimitive;
 use pyo3::{
-    ffi, prelude::*, type_object, types::PyAny, AsPyPointer, PyDowncastError, PyNativeType,
-    PyResult,
+    ffi, prelude::*, pyobject_native_type_info, pyobject_native_type_named, type_object,
+    types::PyAny, AsPyPointer, PyDowncastError, PyNativeType, PyResult,
 };
 use std::{
     cell::Cell,

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -1,11 +1,10 @@
 use crate::npyffi::{NpyTypes, PyArray_Descr, NPY_TYPES, PY_ARRAY_API};
+use cfg_if::cfg_if;
+use pyo3::{ffi, prelude::*, pyobject_native_type_core, types::PyType, AsPyPointer, PyNativeType};
+use std::os::raw::c_int;
+
 pub use num_complex::Complex32 as c32;
 pub use num_complex::Complex64 as c64;
-use pyo3::ffi;
-use pyo3::prelude::*;
-use pyo3::types::PyType;
-use pyo3::{AsPyPointer, PyNativeType};
-use std::os::raw::c_int;
 
 /// Binding of [`numpy.dtype`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.html).
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,6 @@
 //!     })
 //! }
 //! ```
-
-#[macro_use]
-extern crate cfg_if;
-#[macro_use]
-extern crate pyo3;
-
 pub mod array;
 pub mod convert;
 mod dtype;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,8 @@ pub use crate::readonly::{
 pub use crate::sum_products::{dot, einsum_impl, inner};
 pub use ndarray::{array, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 
-/// Test readme
-#[doc(hidden)]
-pub mod doc_test {
+#[cfg(doctest)]
+mod doctest {
     macro_rules! doc_comment {
         ($x: expr, $modname: ident) => {
             #[doc = $x]


### PR DESCRIPTION
So that we do not pull in the pre-1.0 version into other crates dependency tree.