### PR TITLE
Backport fixes for 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Unreleased
+  - Make arrays produced via `IntoPyArray`, i.e. those owning Rust data, writeable ([#235](https://github.com/PyO3/rust-numpy/pull/235))
+
 - v0.15.0
   - [Remove resolver from Cargo.toml](https://github.com/PyO3/rust-numpy/pull/202)
   - [Bump PyO3 to 0.15](https://github.com/PyO3/rust-numpy/pull/212)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-- Unreleased
+- v0.15.1
   - Make arrays produced via `IntoPyArray`, i.e. those owning Rust data, writeable ([#235](https://github.com/PyO3/rust-numpy/pull/235))
+  - Fix thread-safety in internal API globals ([#222](https://github.com/PyO3/rust-numpy/pull/222))
 
 - v0.15.0
   - [Remove resolver from Cargo.toml](https://github.com/PyO3/rust-numpy/pull/202)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.15.0"
+version = "0.15.1"
 authors = [
     "Toshiki Teramura <toshiki.teramura@gmail.com>",
     "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>",

--- a/src/array.rs
+++ b/src/array.rs
@@ -406,7 +406,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
             ptr::null_mut(),   // data
             0,                 // itemsize
             flag,              // flag
-            ptr::null_mut(),   //obj
+            ptr::null_mut(),   // obj
         );
         Self::from_owned_ptr(py, ptr)
     }
@@ -432,11 +432,11 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
             dims.ndim_cint(),
             dims.as_dims_ptr(),
             T::npy_type() as i32,
-            strides as *mut _,          // strides
-            data_ptr as _,              // data
-            mem::size_of::<T>() as i32, // itemsize
-            0,                          // flag
-            ptr::null_mut(),            //obj
+            strides as *mut _,           // strides
+            data_ptr as _,               // data
+            mem::size_of::<T>() as i32,  // itemsize
+            npyffi::NPY_ARRAY_WRITEABLE, // flag
+            ptr::null_mut(),             // obj
         );
         PY_ARRAY_API.PyArray_SetBaseObject(ptr as *mut npyffi::PyArrayObject, cell as _);
         Self::from_owned_ptr(py, ptr)

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -115,6 +115,16 @@ fn into_pyarray_cant_resize() {
     })
 }
 
+#[test]
+fn into_pyarray_can_write() {
+    let a = vec![1, 2, 3];
+    pyo3::Python::with_gil(|py| {
+        let arr = a.into_pyarray(py);
+        pyo3::py_run!(py, arr, "assert arr.flags['WRITEABLE']");
+        pyo3::py_run!(py, arr, "arr[1] = 4");
+    })
+}
+
 /// Check that into_pyarray works for ndarray of which the pointer of the first element is
 /// not at the start. See https://github.com/PyO3/rust-numpy/issues/182 for more
 #[test]


### PR DESCRIPTION
Part of the discussion at https://github.com/PyO3/rust-numpy/pull/240#issuecomment-1006395111

@davidhewitt If I understood https://github.com/PyO3/rust-numpy/pull/233#issuecomment-1005247799 correctly, I should put a `v0.15.1` tag on the last commit here after review?