### PR TITLE
Update metadata in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Support object arrays ([#216](https://github.com/PyO3/rust-numpy/pull/216))
   - Support borrowing arrays that are part of other Python objects via `PyArray::borrow_from_array` ([#230](https://github.com/PyO3/rust-numpy/pull/216))
   - `PyArray::new` is now `unsafe`, as it produces uninitialized arrays ([#220](https://github.com/PyO3/rust-numpy/pull/220))
+  - `rayon` feature is now removed, and directly specifying the feature via `ndarray` dependency is recommended ([#250](https://github.com/PyO3/rust-numpy/pull/250))
 
 - v0.15.1
   - Make arrays produced via `IntoPyArray`, i.e. those owning Rust data, writeable ([#235](https://github.com/PyO3/rust-numpy/pull/235))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,5 @@ pyo3 = { version = "0.15", default-features = false }
 [dev-dependencies]
 pyo3 = { version = "0.15", features = ["auto-initialize"] }
 
-[features]
-default = []
-rayon = ["ndarray/rayon"]
-
 [workspace]
 members = ["examples/*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,16 @@
 name = "numpy"
 version = "0.15.1"
 authors = [
-    "Toshiki Teramura <toshiki.teramura@gmail.com>",
-    "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>",
+    "The rust-numpy Project Developers",
+    "PyO3 Project and Contributors <https://github.com/PyO3>"
 ]
-description = "Rust binding of NumPy C-API"
-documentation = "https://pyo3.github.io/rust-numpy/numpy"
+description = "Rust bindings of NumPy C-API"
+documentation = "https://docs.rs/numpy"
 edition = "2018"
 rust-version = "1.48"
 repository = "https://github.com/PyO3/rust-numpy"
-keywords = ["numpy", "python", "binding"]
+categories = ["api-bindings", "development-tools::ffi", "science"]
+keywords = ["python", "numpy", "ffi", "pyo3"]
 license = "BSD-2-Clause"
 
 [dependencies]


### PR DESCRIPTION
Since some contributors are not involved in PyO3 team (e.g., the original author @termoshtt), I employed dual authorship (rust-numpy and PyO3 developers).
Also, I updated the document link and added `categories`.
Let me know if you have any idea 😃 