### PR TITLE
bump version to 0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.15.0"
+version = "0.15.1"
 authors = [
     "Toshiki Teramura <toshiki.teramura@gmail.com>",
     "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>",


### PR DESCRIPTION
Bumps the version on main to match the newest released.