### PR TITLE
Slim down `Element`, various dtype-related improvements and changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
   - Support borrowing arrays that are part of other Python objects via `PyArray::borrow_from_array` ([#230](https://github.com/PyO3/rust-numpy/pull/216))
   - `PyArray::new` is now `unsafe`, as it produces uninitialized arrays ([#220](https://github.com/PyO3/rust-numpy/pull/220))
   - `rayon` feature is now removed, and directly specifying the feature via `ndarray` dependency is recommended ([#250](https://github.com/PyO3/rust-numpy/pull/250))
+  - Descriptors rework and related changes ([#256](https://github.com/PyO3/rust-numpy/pull/256)):
+    - Remove `DataType`
+    - Add the top-level `dtype` function for easy access to registered dtypes
+    - Add `PyArrayDescr::of`, `PyArrayDescr::into_dtype_ptr` and `PyArrayDescr::is_equiv_to`
+    - `Element` trait has been simplified to just `IS_COPY` const and `get_dtype` method
+    - `Element` is now implemented for `isize`
+    - `c32` and `c64` aliases have been replaced with `Complex32` and `Complex64`
+    - `ShapeError` has been split into `TypeError` and `DimensionalityError`
+    - `i32`, `i64`, `u32` and `u64` are now guaranteed to map to
+      `np.int32`, `np.int64`, `np.uint32` and `np.uint64` respectively
+    - Remove `cfg_if` dependency
 
 - v0.15.1
   - Make arrays produced via `IntoPyArray`, i.e. those owning Rust data, writeable ([#235](https://github.com/PyO3/rust-numpy/pull/235))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["python", "numpy", "ffi", "pyo3"]
 license = "BSD-2-Clause"
 
 [dependencies]
-cfg-if = "1.0"
 libc = "0.2"
 num-complex = ">= 0.2, <= 0.4"
 num-traits = "0.2"

--- a/examples/simple-extension/src/lib.rs
+++ b/examples/simple-extension/src/lib.rs
@@ -1,5 +1,5 @@
 use numpy::ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{c64, IntoPyArray, PyArrayDyn, PyReadonlyArrayDyn};
+use numpy::{Complex64, IntoPyArray, PyArrayDyn, PyReadonlyArrayDyn};
 use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
 
 #[pymodule]
@@ -15,7 +15,7 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     }
 
     // complex example
-    fn conj(x: ArrayViewD<'_, c64>) -> ArrayD<c64> {
+    fn conj(x: ArrayViewD<'_, Complex64>) -> ArrayD<Complex64> {
         x.map(|c| c.conj())
     }
 
@@ -44,7 +44,10 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // wrapper of `conj`
     #[pyfn(m)]
     #[pyo3(name = "conj")]
-    fn conj_py<'py>(py: Python<'py>, x: PyReadonlyArrayDyn<'_, c64>) -> &'py PyArrayDyn<c64> {
+    fn conj_py<'py>(
+        py: Python<'py>,
+        x: PyReadonlyArrayDyn<'_, Complex64>,
+    ) -> &'py PyArrayDyn<Complex64> {
         conj(x.as_array()).into_pyarray(py)
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -168,7 +168,7 @@ impl<T, D> PyArray<T, D> {
     /// pyo3::Python::with_gil(|py| {
     ///    let array = numpy::PyArray::from_vec(py, vec![1, 2, 3i32]);
     ///    let dtype = array.dtype();
-    ///    assert_eq!(dtype.get_datatype().unwrap(), numpy::DataType::Int32);
+    ///    assert!(dtype.is_equiv_to(numpy::PyArrayDescr::of::<i32>(py)));
     /// });
     /// ```
     pub fn dtype(&self) -> &crate::PyArrayDescr {

--- a/src/array.rs
+++ b/src/array.rs
@@ -15,7 +15,7 @@ use std::{
 use std::{iter::ExactSizeIterator, marker::PhantomData};
 
 use crate::convert::{ArrayExt, IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-use crate::dtype::{DataType, Element};
+use crate::dtype::Element;
 use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
 use crate::slice_container::PySliceContainer;
 
@@ -852,7 +852,7 @@ impl<T: Element> PyArray<T, Ix1> {
     pub fn from_slice<'py>(py: Python<'py>, slice: &[T]) -> &'py Self {
         unsafe {
             let array = PyArray::new(py, [slice.len()], false);
-            if T::DATA_TYPE != DataType::Object {
+            if T::IS_COPY {
                 array.copy_ptr(slice.as_ptr(), slice.len());
             } else {
                 let data_ptr = array.data();

--- a/src/array.rs
+++ b/src/array.rs
@@ -168,7 +168,7 @@ impl<T, D> PyArray<T, D> {
     /// pyo3::Python::with_gil(|py| {
     ///    let array = numpy::PyArray::from_vec(py, vec![1, 2, 3i32]);
     ///    let dtype = array.dtype();
-    ///    assert!(dtype.is_equiv_to(numpy::PyArrayDescr::of::<i32>(py)));
+    ///    assert!(dtype.is_equiv_to(numpy::dtype::<i32>(py)));
     /// });
     /// ```
     pub fn dtype(&self) -> &crate::PyArrayDescr {

--- a/src/array.rs
+++ b/src/array.rs
@@ -1225,4 +1225,16 @@ mod tests {
             array.to_dyn().to_owned_array();
         })
     }
+
+    #[test]
+    fn test_hasobject_flag() {
+        use super::ToPyArray;
+        use pyo3::{py_run, types::PyList, Py, PyAny};
+
+        pyo3::Python::with_gil(|py| {
+            let a = ndarray::Array2::from_shape_fn((2, 3), |(_i, _j)| PyList::empty(py).into());
+            let arr: &PyArray<Py<PyAny>, _> = a.to_pyarray(py);
+            py_run!(py, arr, "assert arr.dtype.hasobject");
+        });
+    }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -428,14 +428,13 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         ID: IntoDimension<Dim = D>,
     {
         let dims = dims.into_dimension();
-        let ptr = PY_ARRAY_API.PyArray_New(
+        let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
             PY_ARRAY_API.get_type_object(npyffi::NpyTypes::PyArray_Type),
+            T::get_dtype(py).into_ptr() as _,
             dims.ndim_cint(),
             dims.as_dims_ptr(),
-            T::npy_type() as c_int,
             strides as *mut npy_intp, // strides
             ptr::null_mut(),          // data
-            0,                        // itemsize
             flag,                     // flag
             ptr::null_mut(),          // obj
         );
@@ -453,14 +452,13 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         ID: IntoDimension<Dim = D>,
     {
         let dims = dims.into_dimension();
-        let ptr = PY_ARRAY_API.PyArray_New(
+        let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
             PY_ARRAY_API.get_type_object(npyffi::NpyTypes::PyArray_Type),
+            T::get_dtype(py).into_ptr() as _,
             dims.ndim_cint(),
             dims.as_dims_ptr(),
-            T::npy_type() as c_int,
             strides as *mut npy_intp,     // strides
             data_ptr as *mut c_void,      // data
-            mem::size_of::<T>() as c_int, // itemsize
             npyffi::NPY_ARRAY_WRITEABLE,  // flag
             ptr::null_mut(),              // obj
         );
@@ -1193,7 +1191,7 @@ impl<T: Element + AsPrimitive<f64>> PyArray<T, Ix1> {
                 start.as_(),
                 stop.as_(),
                 step.as_(),
-                T::npy_type() as i32,
+                T::get_dtype(py).get_typenum(),
             );
             Self::from_owned_ptr(py, ptr)
         }

--- a/src/array.rs
+++ b/src/array.rs
@@ -430,7 +430,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         let dims = dims.into_dimension();
         let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
             PY_ARRAY_API.get_type_object(npyffi::NpyTypes::PyArray_Type),
-            T::get_dtype(py).into_ptr() as _,
+            T::get_dtype(py).into_dtype_ptr(),
             dims.ndim_cint(),
             dims.as_dims_ptr(),
             strides as *mut npy_intp, // strides
@@ -454,7 +454,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         let dims = dims.into_dimension();
         let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
             PY_ARRAY_API.get_type_object(npyffi::NpyTypes::PyArray_Type),
-            T::get_dtype(py).into_ptr() as _,
+            T::get_dtype(py).into_dtype_ptr(),
             dims.ndim_cint(),
             dims.as_dims_ptr(),
             strides as *mut npy_intp,     // strides
@@ -567,11 +567,10 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     {
         let dims = dims.into_dimension();
         unsafe {
-            let dtype = T::get_dtype(py);
             let ptr = PY_ARRAY_API.PyArray_Zeros(
                 dims.ndim_cint(),
                 dims.as_dims_ptr(),
-                dtype.into_ptr() as _,
+                T::get_dtype(py).into_dtype_ptr(),
                 if is_fortran { -1 } else { 0 },
             );
             Self::from_owned_ptr(py, ptr)
@@ -1102,10 +1101,9 @@ impl<T: Element, D> PyArray<T, D> {
     /// ```
     pub fn cast<'py, U: Element>(&'py self, is_fortran: bool) -> PyResult<&'py PyArray<U, D>> {
         let ptr = unsafe {
-            let dtype = U::get_dtype(self.py());
             PY_ARRAY_API.PyArray_CastToType(
                 self.as_array_ptr(),
-                dtype.into_ptr() as _,
+                U::get_dtype(self.py()).into_dtype_ptr(),
                 if is_fortran { -1 } else { 0 },
             )
         };

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -7,7 +7,7 @@ use std::{mem, os::raw::c_int};
 
 use crate::{
     npyffi::{self, npy_intp},
-    DataType, Element, PyArray,
+    Element, PyArray,
 };
 
 /// Conversion trait from some rust types to `PyArray`.
@@ -123,7 +123,7 @@ where
     fn to_pyarray<'py>(&self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         let len = self.len();
         match self.order() {
-            Some(order) if A::DATA_TYPE != DataType::Object => {
+            Some(order) if A::IS_COPY => {
                 // if the array is contiguous, copy it by `copy_ptr`.
                 let strides = self.npy_strides();
                 unsafe {

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -259,10 +259,6 @@ impl DataType {
 /// unsafe impl Element for Wrapper {
 ///     const DATA_TYPE: DataType = DataType::Object;
 ///
-///     fn is_same_type(dtype: &PyArrayDescr) -> bool {
-///         dtype.get_datatype() == Some(DataType::Object)
-///     }
-///
 ///     fn get_dtype(py: Python) -> &PyArrayDescr {
 ///         PyArrayDescr::object(py)
 ///     }
@@ -280,9 +276,6 @@ pub unsafe trait Element: Clone + Send {
     /// `DataType` corresponding to this type.
     const DATA_TYPE: DataType;
 
-    /// Returns if the give `dtype` is convertible to `Self` in Rust.
-    fn is_same_type(dtype: &PyArrayDescr) -> bool;
-
     /// Create `dtype`.
     fn get_dtype(py: Python) -> &PyArrayDescr;
 }
@@ -291,10 +284,6 @@ macro_rules! impl_num_element {
     ($ty:ty, $data_type:expr) => {
         unsafe impl Element for $ty {
             const DATA_TYPE: DataType = $data_type;
-
-            fn is_same_type(dtype: &PyArrayDescr) -> bool {
-                dtype.get_datatype() == Some($data_type)
-            }
 
             fn get_dtype(py: Python) -> &PyArrayDescr {
                 PyArrayDescr::from_npy_type(py, $data_type.into_npy_type())
@@ -327,10 +316,6 @@ cfg_if! {
 
 unsafe impl Element for PyObject {
     const DATA_TYPE: DataType = DataType::Object;
-
-    fn is_same_type(dtype: &PyArrayDescr) -> bool {
-        dtype.get_typenum() == NPY_TYPES::NPY_OBJECT as i32
-    }
 
     fn get_dtype(py: Python) -> &PyArrayDescr {
         PyArrayDescr::object(py)

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -107,11 +107,14 @@ impl PyArrayDescr {
 ///
 /// # Safety
 ///
-/// A type `T` that implements this trait should be safe when managed in numpy array,
-/// thus implementing this trait is marked unsafe.
-/// This means that all data types except for `DataType::Object` are assumed to be trivially copyable.
-/// Furthermore, it is assumed that for `DataType::Object` the elements are pointers into the Python heap
-/// and that the corresponding `Clone` implemenation will never panic as it only increases the reference count.
+/// A type `T` that implements this trait should be safe when managed in numpy
+/// array, thus implementing this trait is marked unsafe. Data types that don't
+/// contain Python objects (i.e., either the object type itself or record types
+/// containing object-type fields) are assumed to be trivially copyable, which
+/// is reflected in the `IS_COPY` flag. Furthermore, it is assumed that for
+/// the object type the elements are pointers into the Python heap and that the
+/// corresponding `Clone` implemenation will never panic as it only increases
+/// the reference count.
 ///
 /// # Custom element types
 ///

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -306,3 +306,39 @@ unsafe impl Element for PyObject {
         PyArrayDescr::object(py)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use cfg_if::cfg_if;
+
+    use super::{c32, c64, Element, PyArrayDescr};
+
+    #[test]
+    fn test_dtype_names() {
+        fn type_name<T: Element>(py: pyo3::Python) -> &str {
+            PyArrayDescr::of::<T>(py).get_type().name().unwrap()
+        }
+        pyo3::Python::with_gil(|py| {
+            assert_eq!(type_name::<bool>(py), "bool_");
+            assert_eq!(type_name::<i8>(py), "int8");
+            assert_eq!(type_name::<i16>(py), "int16");
+            assert_eq!(type_name::<i32>(py), "int32");
+            assert_eq!(type_name::<i64>(py), "int64");
+            assert_eq!(type_name::<u8>(py), "uint8");
+            assert_eq!(type_name::<u16>(py), "uint16");
+            assert_eq!(type_name::<u32>(py), "uint32");
+            assert_eq!(type_name::<u64>(py), "uint64");
+            assert_eq!(type_name::<f32>(py), "float32");
+            assert_eq!(type_name::<f64>(py), "float64");
+            assert_eq!(type_name::<c32>(py), "complex64");
+            assert_eq!(type_name::<c64>(py), "complex128");
+            cfg_if! {
+                if #[cfg(target_pointer_width = "64")] {
+                    assert_eq!(type_name::<usize>(py), "uint64");
+                } else if #[cfg(target_pointer_width = "32")] {
+                    assert_eq!(type_name::<usize>(py), "uint32");
+                }
+            }
+        })
+    }
+}

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -84,6 +84,11 @@ impl PyArrayDescr {
         T::get_dtype(py)
     }
 
+    /// Returns true if two type descriptors are equivalent.
+    pub fn is_equiv_to(&self, other: &Self) -> bool {
+        unsafe { PY_ARRAY_API.PyArray_EquivTypes(self.as_dtype_ptr(), other.as_dtype_ptr()) != 0 }
+    }
+
     fn from_npy_type(py: Python, npy_type: NPY_TYPES) -> &Self {
         unsafe {
             let descr = PY_ARRAY_API.PyArray_DescrFromType(npy_type as _);

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -254,8 +254,6 @@ unsafe impl Element for PyObject {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
-
     use super::{dtype, Complex32, Complex64, Element};
 
     #[test]
@@ -277,16 +275,15 @@ mod tests {
             assert_eq!(type_name::<f64>(py), "float64");
             assert_eq!(type_name::<Complex32>(py), "complex64");
             assert_eq!(type_name::<Complex64>(py), "complex128");
-            match size_of::<usize>() {
-                32 => {
-                    assert_eq!(type_name::<usize>(py), "uint32");
-                    assert_eq!(type_name::<isize>(py), "int32");
-                }
-                64 => {
-                    assert_eq!(type_name::<usize>(py), "uint64");
-                    assert_eq!(type_name::<isize>(py), "int64");
-                }
-                _ => {}
+            #[cfg(target_pointer_width = "32")]
+            {
+                assert_eq!(type_name::<usize>(py), "uint32");
+                assert_eq!(type_name::<isize>(py), "int32");
+            }
+            #[cfg(target_pointer_width = "64")]
+            {
+                assert_eq!(type_name::<usize>(py), "uint64");
+                assert_eq!(type_name::<isize>(py), "int64");
             }
         });
     }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -20,7 +20,7 @@ pub use num_complex::{Complex32, Complex64};
 ///         .unwrap()
 ///         .downcast()
 ///         .unwrap();
-///     assert!(dtype.is_equiv_to(numpy::PyArrayDescr::of::<f64>(py)));
+///     assert!(dtype.is_equiv_to(numpy::dtype::<f64>(py)));
 /// });
 /// ```
 pub struct PyArrayDescr(PyAny);
@@ -37,6 +37,11 @@ unsafe fn arraydescr_check(op: *mut ffi::PyObject) -> c_int {
         op,
         PY_ARRAY_API.get_type_object(NpyTypes::PyArrayDescr_Type),
     )
+}
+
+/// Returns the type descriptor ("dtype") for a registered type.
+pub fn dtype<T: Element>(py: Python) -> &PyArrayDescr {
+    T::get_dtype(py)
 }
 
 impl PyArrayDescr {
@@ -72,7 +77,7 @@ impl PyArrayDescr {
         Self::from_npy_type(py, NPY_TYPES::NPY_OBJECT)
     }
 
-    /// Returns the type descriptor for a registered type.
+    /// Returns the type descriptor ("dtype") for a registered type.
     pub fn of<T: Element>(py: Python) -> &Self {
         T::get_dtype(py)
     }
@@ -251,12 +256,12 @@ unsafe impl Element for PyObject {
 mod tests {
     use std::mem::size_of;
 
-    use super::{Complex32, Complex64, Element, PyArrayDescr};
+    use super::{dtype, Complex32, Complex64, Element};
 
     #[test]
     fn test_dtype_names() {
         fn type_name<T: Element>(py: pyo3::Python) -> &str {
-            PyArrayDescr::of::<T>(py).get_type().name().unwrap()
+            dtype::<T>(py).get_type().name().unwrap()
         }
         pyo3::Python::with_gil(|py| {
             assert_eq!(type_name::<bool>(py), "bool_");

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -43,6 +43,13 @@ impl PyArrayDescr {
         self.as_ptr() as _
     }
 
+    /// Returns `self` as `*mut PyArray_Descr` while increasing the reference count.
+    ///
+    /// Useful in cases where the descriptor is stolen by the API.
+    pub fn into_dtype_ptr(&self) -> *mut PyArray_Descr {
+        self.into_ptr() as _
+    }
+
     /// Returns the internal `PyType` that this `dtype` holds.
     ///
     /// # Example

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -75,6 +75,11 @@ impl PyArrayDescr {
         Self::from_npy_type(py, NPY_TYPES::NPY_OBJECT)
     }
 
+    /// Returns the type descriptor for a registered type.
+    pub fn of<T: Element>(py: Python) -> &Self {
+        T::get_dtype(py)
+    }
+
     fn from_npy_type(py: Python, npy_type: NPY_TYPES) -> &Self {
         unsafe {
             let descr = PY_ARRAY_API.PyArray_DescrFromType(npy_type as i32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use crate::array::{
     PyArray6, PyArrayDyn,
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-pub use crate::dtype::{Complex32, Complex64, DataType, Element, PyArrayDescr};
+pub use crate::dtype::{Complex32, Complex64, Element, PyArrayDescr};
 pub use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::npyiter::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use crate::array::{
     PyArray6, PyArrayDyn,
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-pub use crate::dtype::{c32, c64, DataType, Element, PyArrayDescr};
+pub use crate::dtype::{Complex32, Complex64, DataType, Element, PyArrayDescr};
 pub use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::npyiter::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use crate::array::{
     PyArray6, PyArrayDyn,
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-pub use crate::dtype::{Complex32, Complex64, Element, PyArrayDescr};
+pub use crate::dtype::{dtype, Complex32, Complex64, Element, PyArrayDescr};
 pub use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::npyiter::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::array::{
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 pub use crate::dtype::{c32, c64, DataType, Element, PyArrayDescr};
-pub use crate::error::{FromVecError, NotContiguousError, ShapeError};
+pub use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::npyiter::{
     IterMode, NpyIterFlag, NpyMultiIter, NpyMultiIterBuilder, NpySingleIter, NpySingleIterBuilder,

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -249,7 +249,7 @@ fn dtype_from_py() {
             .downcast()
             .unwrap();
         assert_eq!(&format!("{:?}", dtype), "dtype('uint32')");
-        assert!(dtype.is_equiv_to(numpy::PyArrayDescr::of::<u32>(py)));
+        assert!(dtype.is_equiv_to(numpy::dtype::<u32>(py)));
     })
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -249,7 +249,7 @@ fn dtype_from_py() {
             .downcast()
             .unwrap();
         assert_eq!(&format!("{:?}", dtype), "dtype('uint32')");
-        assert_eq!(dtype.get_datatype().unwrap(), numpy::DataType::Uint32);
+        assert!(dtype.is_equiv_to(numpy::PyArrayDescr::of::<u32>(py)));
     })
 }
 


### PR DESCRIPTION
@adamreichold Here comes, as promised 😄 

This is the preliminary PR to enable further work on #254.

Although there's some breaking changes in here, it's probably better to do it all in one batch because many of these changes are inter-related. I believe all changes are improvements, in one way or another; and there's also some fixes.

An unsorted list of changes:

- Replace `Element::DATA_TYPE` with `Element::IS_POD`
  - Otherwise, we would run into serious complications when trying to implement record types. Also, this is much simpler since all we need really is a quick way to check whether a type is pod or not.
- Remove `Element::same_type()`
  - This was based on typenums and wouldn't work with more complex types. Now it uses `PyArray_EquivTypes`.
- Use `PyArray_NewFromDescr` instead of `PyArray_New` to create arrays.
  - This detaches it from typenums and will allow using custom descriptors later on.
- Added a FIXME note in `FromPyObject::extract()` - it currently doesn't check the instance type and only verifies that dtype is 'O' which may and will lead to unsafe behaviour and so it has to be fixed.
- Split a weird `ShapeError` into `DimensionalityError` and `TypeError`. The latter is no longer typenum-based either and would work with any dtypes; formatting is left for numpy to handle.
- Add methods to `PyArrayDescr`:
  - `into_dtype_ptr()` - an alternative to `as_dtype_ptr()` that increfs it; useful since numpy API often steals descriptor references
  - `of<T>()` - an equivalent to `pybind11::dtype::of<T>()`
  - `is_equiv_to()` - to check if descriptor types are equivalent (`PyArray_EquivTypes`)
  - `get_typenum()` is made public since `DataType::from_typenum()` is public; doesn't make much sense to hide it
  - `object()` - a shortcut for creating 'O' dtype (useful in user implementations of `Element`)
- Add `get_typenum()` to `DataType`
- Fix how integer types are mapped to npy types and added a test for it (which was previously failing):
  - As an example, `DataType::Uint64` could be previously mapped to `np.c_ulonglong` instead of `np.uint64` which is *not* the same thing. Now, `u64` always maps to `np.uint64`.
  - Now it uses the same logic as numpy itself (and same as in pybind11)
  - Reverse conversions (npy -> DataType) have also been reimplemented and cleaned up
- Implemented `Element` for `isize`

Open question: one thing that I find extremely confusing is that `DataType::Complex32` maps to `np.complex64` (and `Complex64` maps to `np.complex128`). Wouldn't it make more sense if they were named consistently? (i.e. same as in numpy, 64/128)

(if this is accepted, I can also work on updating the changelog if needed so.)