### PR TITLE
`PyArrayDescr` methods like in `np.dtype` + some missing stuff in `npyffi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
     - `i32`, `i64`, `u32` and `u64` are now guaranteed to map to
       `np.int32`, `np.int64`, `np.uint32` and `np.uint64` respectively
     - Remove `cfg_if` dependency
+  - New methods in `PyArrayDescr`, catching up with `np.dtype`:
+    - `num`, `base`, `ndim`, `shape`, `byteorder`, `char`, `kind`, `itemsize`,
+      `alignment`, `flags`, `has_object`, `is_aligned_struct`, `names`
+    - Added `get_field` to query fields of structured dtypes
+    - Additional helper methods: `has_subarray`, `has_fields`, `is_native_byteorder`
+    - Renamed `get_type` to `typeobj`
 
 - v0.15.1
   - Make arrays produced via `IntoPyArray`, i.e. those owning Rust data, writeable ([#235](https://github.com/PyO3/rust-numpy/pull/235))

--- a/src/array.rs
+++ b/src/array.rs
@@ -1219,7 +1219,7 @@ impl<T: Element + AsPrimitive<f64>> PyArray<T, Ix1> {
                 start.as_(),
                 stop.as_(),
                 step.as_(),
-                T::get_dtype(py).get_typenum(),
+                T::get_dtype(py).num(),
             );
             Self::from_owned_ptr(py, ptr)
         }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -118,7 +118,7 @@ impl PyArrayDescr {
         unsafe { *self.as_dtype_ptr() }.elsize.max(0) as _
     }
 
-    /// Returns the required alignment (bytes) of this data-type according to the compiler
+    /// Returns the required alignment (bytes) of this data-type according to the compiler.
     ///
     /// Equivalent to [`np.dtype.alignment`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.alignment.html).
     pub fn alignment(&self) -> usize {
@@ -138,7 +138,7 @@ impl PyArrayDescr {
     ///
     /// Note: structured data types are categorized as `V` (void).
     ///
-    /// Equivalent to [`np.dtype.char`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.char.html)
+    /// Equivalent to [`np.dtype.char`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.char.html).
     pub fn char(&self) -> u8 {
         unsafe { *self.as_dtype_ptr() }.type_.max(0) as _
     }
@@ -147,21 +147,21 @@ impl PyArrayDescr {
     ///
     /// Note: structured data types are categorized as `V` (void).
     ///
-    /// Equivalent to [`np.dtype.kind`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html)
+    /// Equivalent to [`np.dtype.kind`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html).
     pub fn kind(&self) -> u8 {
         unsafe { *self.as_dtype_ptr() }.kind.max(0) as _
     }
 
     /// Returns bit-flags describing how this data type is to be interpreted.
     ///
-    /// Equivalent to [`np.dtype.flags`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.flags.html)
+    /// Equivalent to [`np.dtype.flags`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.flags.html).
     pub fn flags(&self) -> c_char {
         unsafe { *self.as_dtype_ptr() }.flags
     }
 
     /// Returns the number of dimensions if this data type describes a sub-array, and `0` otherwise.
     ///
-    /// Equivalent to [`np.dtype.ndim`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.ndim.html)
+    /// Equivalent to [`np.dtype.ndim`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.ndim.html).
     pub fn ndim(&self) -> usize {
         if !self.has_subarray() {
             return 0;
@@ -181,7 +181,7 @@ impl PyArrayDescr {
 
     /// Returns shape tuple of the sub-array if this dtype is a sub-array, and `None` otherwise.
     ///
-    /// Equivalent to [`np.dtype.shape`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.shape.html)
+    /// Equivalent to [`np.dtype.shape`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.shape.html).
     pub fn shape(&self) -> Option<Vec<usize>> {
         if !self.has_subarray() {
             return None;
@@ -204,7 +204,7 @@ impl PyArrayDescr {
     /// If a field whose dtype object has this attribute is retrieved, then the extra dimensions
     /// implied by shape are tacked on to the end of the retrieved array.
     ///
-    /// Equivalent to [`np.dtype.subdtype`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.subdtype.html)
+    /// Equivalent to [`np.dtype.subdtype`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.subdtype.html).
     pub fn subdtype(&self) -> Option<(&PyArrayDescr, Vec<usize>)> {
         self.shape()
             .and_then(|shape| self.base().map(|base| (base, shape)))
@@ -212,7 +212,7 @@ impl PyArrayDescr {
 
     /// Returns true if the dtype is a sub-array at the top level.
     ///
-    /// Equivalent to [`np.dtype.hasobject`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.hasobject.html)
+    /// Equivalent to [`np.dtype.hasobject`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.hasobject.html).
     pub fn has_object(&self) -> bool {
         self.flags() & NPY_ITEM_HASOBJECT != 0
     }
@@ -222,7 +222,7 @@ impl PyArrayDescr {
     /// This flag is sticky, so when combining multiple structs together, it is preserved
     /// and produces new dtypes which are also aligned.
     ///
-    /// Equivalent to [`np.dtype.isalignedstruct`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.isalignedstruct.html)
+    /// Equivalent to [`np.dtype.isalignedstruct`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.isalignedstruct.html).
     pub fn is_aligned_struct(&self) -> bool {
         self.flags() & NPY_ALIGNED_STRUCT != 0
     }
@@ -239,7 +239,7 @@ impl PyArrayDescr {
         unsafe { !(*self.as_dtype_ptr()).names.is_null() }
     }
 
-    /// Returns true if the data type is unsized
+    /// Returns true if the data type is unsized.
     pub fn is_unsized(&self) -> bool {
         // equivalent to PyDataType_ISUNSIZED(self)
         self.itemsize() == 0 && !self.has_fields()

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -236,12 +236,6 @@ impl PyArrayDescr {
         unsafe { !(*self.as_dtype_ptr()).names.is_null() }
     }
 
-    /// Returns true if the data type is unsized.
-    pub fn is_unsized(&self) -> bool {
-        // equivalent to PyDataType_ISUNSIZED(self)
-        self.itemsize() == 0 && !self.has_fields()
-    }
-
     /// Returns true if data type byteorder is native, or `None` if not applicable.
     pub fn is_native_byteorder(&self) -> Option<bool> {
         // based on PyArray_ISNBO(self->byteorder)

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -177,12 +177,17 @@ impl PyArrayDescr {
 
     /// Returns dtype for the base element of subarrays, regardless of their dimension or shape.
     ///
+    /// If the dtype is not a subarray, returns self.
+    ///
     /// Equivalent to [`np.dtype.base`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.base.html).
-    pub fn base(&self) -> Option<&PyArrayDescr> {
+    pub fn base(&self) -> &PyArrayDescr {
         if !self.has_subarray() {
-            return None;
+            self
+        } else {
+            unsafe {
+                Self::from_borrowed_ptr(self.py(), (*(*self.as_dtype_ptr()).subarray).base as _)
+            }
         }
-        Some(unsafe { Self::from_borrowed_ptr(self.py(), (*self.as_dtype_ptr()).subarray as _) })
     }
 
     /// Returns shape tuple of the sub-array if this dtype is a sub-array, and `None` otherwise.

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -190,21 +190,22 @@ impl PyArrayDescr {
         }
     }
 
-    /// Returns shape tuple of the sub-array if this dtype is a sub-array, and `None` otherwise.
+    /// Returns the shape of the sub-array.
+    ///
+    /// If the dtype is not a sub-array, an empty vector is returned.
     ///
     /// Equivalent to [`np.dtype.shape`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.shape.html).
-    pub fn shape(&self) -> Option<Vec<usize>> {
+    pub fn shape(&self) -> Vec<usize> {
         if !self.has_subarray() {
-            return None;
-        }
-        Some(
+            vec![]
+        } else {
             // Panic-wise: numpy guarantees that shape is a tuple of non-negative integers
             unsafe {
                 PyTuple::from_borrowed_ptr(self.py(), (*(*self.as_dtype_ptr()).subarray).shape)
             }
             .extract()
-            .unwrap(),
-        )
+            .unwrap()
+        }
     }
 
     /// Returns true if the dtype is a sub-array at the top level.
@@ -501,7 +502,7 @@ mod tests {
             assert!(!dt.has_subarray());
             assert!(dt.base().is_equiv_to(dt));
             assert_eq!(dt.ndim(), 0);
-            assert_eq!(dt.shape(), None);
+            assert_eq!(dt.shape(), vec![]);
         });
     }
 
@@ -535,7 +536,7 @@ mod tests {
             assert!(!dt.is_aligned_struct());
             assert!(dt.has_subarray());
             assert_eq!(dt.ndim(), 2);
-            assert_eq!(dt.shape().unwrap(), vec![2, 3]);
+            assert_eq!(dt.shape(), vec![2, 3]);
             assert!(dt.base().is_equiv_to(dtype::<f64>(py)));
         });
     }
@@ -572,7 +573,7 @@ mod tests {
             assert!(dt.is_aligned_struct());
             assert!(!dt.has_subarray());
             assert_eq!(dt.ndim(), 0);
-            assert_eq!(dt.shape(), None);
+            assert_eq!(dt.shape(), vec![]);
             assert!(dt.base().is_equiv_to(dt));
             let x = dt.get_field("x").unwrap();
             assert!(x.0.is_equiv_to(dtype::<u8>(py)));

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -101,6 +101,12 @@ impl PyArrayDescr {
         unsafe { PyType::from_type_ptr(self.py(), dtype_type_ptr) }
     }
 
+    #[doc(hidden)]
+    #[deprecated(note = "`get_type()` is deprecated, please use `typeobj()` instead")]
+    pub fn get_type(&self) -> &PyType {
+        self.typeobj()
+    }
+
     /// Returns a unique number for each of the 21 different built-in
     /// [enumerated types](https://numpy.org/doc/stable/reference/c-api/dtype.html#enumerated-types).
     ///

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -94,10 +94,13 @@ impl PyArrayDescr {
         }
     }
 
-    /// Retrieves the
-    /// [enumerated type](https://numpy.org/doc/stable/reference/c-api/dtype.html#enumerated-types)
-    /// for this type descriptor.
-    pub fn get_typenum(&self) -> c_int {
+    /// Returns a unique number for each of the 21 different built-in
+    /// [enumerated types](https://numpy.org/doc/stable/reference/c-api/dtype.html#enumerated-types).
+    ///
+    /// These are roughly ordered from least-to-most precision.
+    ///
+    /// Equivalent to [`np.dtype.num`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.num.html).
+    pub fn num(&self) -> c_int {
         unsafe { *self.as_dtype_ptr() }.type_num
     }
 }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -202,20 +202,6 @@ impl PyArrayDescr {
         )
     }
 
-    /// Returns `(item_dtype, shape)` if this dtype describes a sub-array, and `None` otherwise.
-    ///
-    /// The `shape` is the fixed shape of the sub-array described by this data type,
-    /// and `item_dtype` the data type of the array.
-    ///
-    /// If a field whose dtype object has this attribute is retrieved, then the extra dimensions
-    /// implied by shape are tacked on to the end of the retrieved array.
-    ///
-    /// Equivalent to [`np.dtype.subdtype`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.subdtype.html).
-    pub fn subdtype(&self) -> Option<(&PyArrayDescr, Vec<usize>)> {
-        self.shape()
-            .and_then(|shape| self.base().map(|base| (base, shape)))
-    }
-
     /// Returns true if the dtype is a sub-array at the top level.
     ///
     /// Equivalent to [`np.dtype.hasobject`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.hasobject.html).

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -394,6 +394,12 @@ pub unsafe fn PyArray_CheckExact(op: *mut PyObject) -> c_int {
     (ffi::Py_TYPE(op) == PY_ARRAY_API.get_type_object(NpyTypes::PyArray_Type)) as _
 }
 
+// these are under `#if NPY_USE_PYMEM == 1` which seems to be always defined as 1
+pub use pyo3::ffi::{
+    PyMem_RawFree as PyArray_free, PyMem_RawMalloc as PyArray_malloc,
+    PyMem_RawRealloc as PyArray_realloc,
+};
+
 #[cfg(test)]
 mod tests {
     use super::PY_ARRAY_API;

--- a/src/npyffi/flags.rs
+++ b/src/npyffi/flags.rs
@@ -1,4 +1,4 @@
-use super::npy_uint32;
+use super::{npy_char, npy_uint32};
 use std::os::raw::c_int;
 
 pub const NPY_ARRAY_C_CONTIGUOUS: c_int = 0x0001;
@@ -62,3 +62,21 @@ pub const NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE: npy_uint32 = 0x40000000;
 
 pub const NPY_ITER_GLOBAL_FLAGS: npy_uint32 = 0x0000ffff;
 pub const NPY_ITER_PER_OP_FLAGS: npy_uint32 = 0xffff0000;
+
+pub const NPY_ITEM_REFCOUNT: npy_char = 0x01;
+pub const NPY_ITEM_HASOBJECT: npy_char = 0x01;
+pub const NPY_LIST_PICKLE: npy_char = 0x02;
+pub const NPY_ITEM_IS_POINTER: npy_char = 0x04;
+pub const NPY_NEEDS_INIT: npy_char = 0x08;
+pub const NPY_NEEDS_PYAPI: npy_char = 0x10;
+pub const NPY_USE_GETITEM: npy_char = 0x20;
+pub const NPY_USE_SETITEM: npy_char = 0x40;
+pub const NPY_ALIGNED_STRUCT: npy_char = -128; // 0x80
+pub const NPY_FROM_FIELDS: npy_char =
+    NPY_NEEDS_INIT | NPY_LIST_PICKLE | NPY_ITEM_REFCOUNT | NPY_NEEDS_PYAPI;
+pub const NPY_OBJECT_DTYPE_FLAGS: npy_char = NPY_LIST_PICKLE
+    | NPY_USE_GETITEM
+    | NPY_ITEM_IS_POINTER
+    | NPY_ITEM_REFCOUNT
+    | NPY_NEEDS_INIT
+    | NPY_NEEDS_PYAPI;

--- a/src/npyffi/objects.rs
+++ b/src/npyffi/objects.rs
@@ -398,3 +398,17 @@ pub struct NpyAuxData {
 
 pub type NpyAuxData_FreeFunc = Option<unsafe extern "C" fn(*mut NpyAuxData)>;
 pub type NpyAuxData_CloneFunc = Option<unsafe extern "C" fn(*mut NpyAuxData) -> *mut NpyAuxData>;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PyArray_DatetimeMetaData {
+    pub base: NPY_DATETIMEUNIT,
+    pub num: c_int,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PyArray_DatetimeDTypeMetaData {
+    pub base: NpyAuxData,
+    pub meta: PyArray_DatetimeMetaData,
+}

--- a/src/npyffi/types.rs
+++ b/src/npyffi/types.rs
@@ -204,7 +204,7 @@ pub struct npy_stride_sort_item {
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy)]
-enum NPY_TYPECHAR {
+pub enum NPY_TYPECHAR {
     NPY_BOOLLTR = b'?',
     NPY_BYTELTR = b'b',
     NPY_UBYTELTR = b'B',
@@ -239,7 +239,7 @@ enum NPY_TYPECHAR {
 #[derive(Debug, Clone, Copy)]
 // NPY_TYPEKINDCHAR doesn't exist in the header, but these enum values are not
 // related to NPY_TYPECHAR although being stuffed into it (type kinds, not type codes)
-enum NPY_TYPEKINDCHAR {
+pub enum NPY_TYPEKINDCHAR {
     NPY_GENBOOLLTR = b'b',
     NPY_SIGNEDLTR = b'i',
     NPY_UNSIGNEDLTR = b'u',

--- a/src/npyffi/types.rs
+++ b/src/npyffi/types.rs
@@ -115,7 +115,7 @@ pub enum NPY_DATETIMEUNIT {
 }
 
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum NPY_TYPES {
     NPY_BOOL = 0,
     NPY_BYTE = 1,

--- a/src/npyffi/types.rs
+++ b/src/npyffi/types.rs
@@ -235,10 +235,12 @@ pub enum NPY_TYPECHAR {
     NPY_UINTPLTR = b'P',
 }
 
+// Note: NPY_TYPEKINDCHAR doesn't exist in the header and has been created here artificially
+// because the original C enum contained duplicate values - namely, those related to type kinds.
+// There's also a comment in the C code preceding this block of values and stating that they are
+// related to type kind chars and not type codes.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy)]
-// NPY_TYPEKINDCHAR doesn't exist in the header, but these enum values are not
-// related to NPY_TYPECHAR although being stuffed into it (type kinds, not type codes)
 pub enum NPY_TYPEKINDCHAR {
     NPY_GENBOOLLTR = b'b',
     NPY_SIGNEDLTR = b'i',

--- a/src/npyffi/types.rs
+++ b/src/npyffi/types.rs
@@ -201,3 +201,70 @@ pub struct npy_stride_sort_item {
     pub perm: npy_intp,
     pub stride: npy_intp,
 }
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+enum NPY_TYPECHAR {
+    NPY_BOOLLTR = b'?',
+    NPY_BYTELTR = b'b',
+    NPY_UBYTELTR = b'B',
+    NPY_SHORTLTR = b'h',
+    NPY_USHORTLTR = b'H',
+    NPY_INTLTR = b'i',
+    NPY_UINTLTR = b'I',
+    NPY_LONGLTR = b'l',
+    NPY_ULONGLTR = b'L',
+    NPY_LONGLONGLTR = b'q',
+    NPY_ULONGLONGLTR = b'Q',
+    NPY_HALFLTR = b'e',
+    NPY_FLOATLTR = b'f',
+    NPY_DOUBLELTR = b'd',
+    NPY_LONGDOUBLELTR = b'g',
+    NPY_CFLOATLTR = b'F',
+    NPY_CDOUBLELTR = b'D',
+    NPY_CLONGDOUBLELTR = b'G',
+    NPY_OBJECTLTR = b'O',
+    NPY_STRINGLTR = b'S',
+    NPY_STRINGLTR2 = b'a',
+    NPY_UNICODELTR = b'U',
+    NPY_VOIDLTR = b'V',
+    NPY_DATETIMELTR = b'M',
+    NPY_TIMEDELTALTR = b'm',
+    NPY_CHARLTR = b'c',
+    NPY_INTPLTR = b'p',
+    NPY_UINTPLTR = b'P',
+}
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+// NPY_TYPEKINDCHAR doesn't exist in the header, but these enum values are not
+// related to NPY_TYPECHAR although being stuffed into it (type kinds, not type codes)
+enum NPY_TYPEKINDCHAR {
+    NPY_GENBOOLLTR = b'b',
+    NPY_SIGNEDLTR = b'i',
+    NPY_UNSIGNEDLTR = b'u',
+    NPY_FLOATINGLTR = b'f',
+    NPY_COMPLEXLTR = b'c',
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum NPY_BYTEORDER_CHAR {
+    NPY_LITTLE = b'<',
+    NPY_BIG = b'>',
+    NPY_NATIVE = b'=',
+    NPY_SWAP = b's',
+    NPY_IGNORE = b'|',
+}
+
+impl NPY_BYTEORDER_CHAR {
+    #[cfg(target_endian = "little")]
+    pub const NPY_NATBYTE: Self = Self::NPY_LITTLE;
+    #[cfg(target_endian = "little")]
+    pub const NPY_OPPBYTE: Self = Self::NPY_BIG;
+
+    #[cfg(target_endian = "big")]
+    pub const NPY_NATBYTE: Self = Self::NPY_BIG;
+    #[cfg(target_endian = "big")]
+    pub const NPY_OPPBYTE: Self = Self::NPY_LITTLE;
+}


### PR DESCRIPTION
- The `npyffi` stuff has been pulled out of [`pyo3-type-desc`](https://github.com/aldanor/pyo3-type-desc).
- Methods in `PyArrayDescr` mostly replicate `np.dtype` object, plus a few methods replicating C macros (this will greatly simplify writing tests in `pyo3-type-desc`, plus makes `PyArrayDescr` object somewhat useful).