### PR TITLE
RFC: Mark the read-write variants of the NumPy iterators unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Support borrowing arrays that are part of other Python objects via `PyArray::borrow_from_array` ([#230](https://github.com/PyO3/rust-numpy/pull/216))
   - Fixed downcasting ignoring element type and dimensionality ([#265](https://github.com/PyO3/rust-numpy/pull/265))
   - `PyArray::new` is now `unsafe`, as it produces uninitialized arrays ([#220](https://github.com/PyO3/rust-numpy/pull/220))
+  - `PyArray::iter`, `NpySingleIterBuilder::readwrite` and `NpyMultiIterBuilder::add_readwrite` are now `unsafe`, as they allow aliasing mutable references to be created ([#278/](https://github.com/PyO3/rust-numpy/pull/278))
   - `PyArray::from_exact_iter` does not unsoundly trust `ExactSizeIterator::len` any more ([#262](https://github.com/PyO3/rust-numpy/pull/262))
   - `PyArray::as_cell_slice` was removed as it unsoundly interacts with `PyReadonlyArray` allowing safe code to violate aliasing rules ([#260](https://github.com/PyO3/rust-numpy/pull/260))
   - `rayon` feature is now removed, and directly specifying the feature via `ndarray` dependency is recommended ([#250](https://github.com/PyO3/rust-numpy/pull/250))
@@ -19,10 +20,8 @@
     - `i32`, `i64`, `u32`, `u64` are now guaranteed to map to `np.u?int{32,64}`.
     - Removed `cfg_if` dependency
     - Removed `DataType` enum
-  - Added `PyArrayDescr::new` constructor
-    ([#266](https://github.com/PyO3/rust-numpy/pull/266))
-  - New `PyArrayDescr` methods
-    ([#266](https://github.com/PyO3/rust-numpy/pull/261)):
+  - Added `PyArrayDescr::new` constructor ([#266](https://github.com/PyO3/rust-numpy/pull/266))
+  - New `PyArrayDescr` methods ([#266](https://github.com/PyO3/rust-numpy/pull/261)):
     - `num`, `base`, `ndim`, `shape`, `byteorder`, `char`, `kind`, `itemsize`,
       `alignment`, `flags`, `has_object`, `is_aligned_struct`, `names`,
       `get_field`, `has_subarray`, `has_fields`, `is_native_byteorder`

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -28,7 +28,7 @@ fn mutable_iter() -> PyResult<()> {
     let data = array![[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]];
     pyo3::Python::with_gil(|py| {
         let arr = PyArray::from_array(py, &data);
-        let iter = NpySingleIterBuilder::readwrite(arr).build()?;
+        let iter = unsafe { NpySingleIterBuilder::readwrite(arr).build()? };
         for elem in iter {
             *elem *= 2.0;
         }
@@ -71,10 +71,12 @@ fn multiiter_rw() -> PyResult<()> {
     pyo3::Python::with_gil(|py| {
         let arr1 = PyArray::from_array(py, &data1);
         let arr2 = PyArray::from_array(py, &data2);
-        let iter = NpyMultiIterBuilder::new()
-            .add_readonly(arr1.readonly())
-            .add_readwrite(arr2)
-            .build()?;
+        let iter = unsafe {
+            NpyMultiIterBuilder::new()
+                .add_readonly(arr1.readonly())
+                .add_readwrite(arr2)
+                .build()?
+        };
 
         for (x, y) in iter {
             *y = *x * 2.0;


### PR DESCRIPTION
For the same reason that `PyArray::as_array` is unsafe, i.e. the lack of control over aliasing even for safe Rust code producing multiple iterators.

(I am not totally sure whether this is the right thing to do as I would mark them safe again in #274 after adding dynamic borrow checking but it appears slightly inconsistent as it is.)