### PR TITLE
Deprecate the wrappers of the array iterator API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Fixed downcasting ignoring element type and dimensionality ([#265](https://github.com/PyO3/rust-numpy/pull/265))
   - `PyArray::new` is now `unsafe`, as it produces uninitialized arrays ([#220](https://github.com/PyO3/rust-numpy/pull/220))
   - `PyArray::iter`, `NpySingleIterBuilder::readwrite` and `NpyMultiIterBuilder::add_readwrite` are now `unsafe`, as they allow aliasing mutable references to be created ([#278/](https://github.com/PyO3/rust-numpy/pull/278))
+  - The `npyiter` module is deprecated as rust-ndarray's facilities for iteration are more flexible and performant ([#280](https://github.com/PyO3/rust-numpy/pull/280))
   - `PyArray::from_exact_iter` does not unsoundly trust `ExactSizeIterator::len` any more ([#262](https://github.com/PyO3/rust-numpy/pull/262))
   - `PyArray::as_cell_slice` was removed as it unsoundly interacts with `PyReadonlyArray` allowing safe code to violate aliasing rules ([#260](https://github.com/PyO3/rust-numpy/pull/260))
   - `rayon` feature is now removed, and directly specifying the feature via `ndarray` dependency is recommended ([#250](https://github.com/PyO3/rust-numpy/pull/250))

--- a/src/array.rs
+++ b/src/array.rs
@@ -23,6 +23,7 @@ use crate::convert::{ArrayExt, IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 use crate::dtype::{Element, PyArrayDescr};
 use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
 use crate::npyffi::{self, npy_intp, NPY_ORDER, PY_ARRAY_API};
+#[allow(deprecated)]
 use crate::npyiter::{NpySingleIter, NpySingleIterBuilder, ReadWrite};
 use crate::readonly::PyReadonlyArray;
 use crate::slice_container::PySliceContainer;
@@ -1079,6 +1080,10 @@ impl<T: Element> PyArray<T, Ix1> {
     ///
     /// The iterator will produce mutable references into the array which must not be
     /// aliased by other references for the life time of the iterator.
+    #[deprecated(
+        note = "The wrappers of the array iterator API are deprecated, please use ndarray's `ArrayBase::iter_mut` instead."
+    )]
+    #[allow(deprecated)]
     pub unsafe fn iter<'py>(&'py self) -> PyResult<NpySingleIter<'py, T, ReadWrite>> {
         NpySingleIterBuilder::readwrite(self).build()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 pub use crate::dtype::{dtype, Complex32, Complex64, Element, PyArrayDescr};
 pub use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
+#[allow(deprecated)]
 pub use crate::npyiter::{
     IterMode, NpyIterFlag, NpyMultiIter, NpyMultiIterBuilder, NpySingleIter, NpySingleIterBuilder,
 };

--- a/src/npyiter.rs
+++ b/src/npyiter.rs
@@ -1,14 +1,31 @@
-//! Wrapper of [Array Iterator API](https://numpy.org/doc/stable/reference/c-api/iterator.html).
+//! Wrapper of the [array iterator API][iterator].
 //!
-//! This module exposes two iterators:
-//! [NpySingleIter](./struct.NpySingleIter.html) and
-//! [NpyMultiIter](./struct.NpyMultiIter.html).
+//! This module exposes two iterators: [`NpySingleIter`] and [`NpyMultiIter`].
+//!
+//! As general recommendation, the usage of ndarray's facilities for iteration should be preferred:
+//!
+//! * They are more performant due to being transparent to the Rust compiler, using statically known dimensions
+//!   without dynamic dispatch into NumPy's C implementation, c.f. [`ndarray::iter::Iter`].
+//! * They are more flexible as to which parts of the array iterated in which order, c.f. [`ndarray::iter::Lanes`].
+//! * They can zip up to six arrays together and operate on their elements using multiple threads, c.f. [`ndarray::Zip`].
+//!
+//! To safely use these types, extension functions should take [`PyReadonlyArray`] as arguments
+//! which provide the [`as_array`][PyReadonlyArray::as_array] method to acquire an [`ndarray::ArrayView`].
+//!
+//! [iterator]: https://numpy.org/doc/stable/reference/c-api/iterator.html
 #![deprecated(
     note = "The wrappers of the array iterator API are deprecated, please use ndarray's iterators like `Lanes` and `Zip` instead."
 )]
 
-use pyo3::{prelude::*, PyNativeType};
+use std::marker::PhantomData;
+use std::os::raw::{c_char, c_int};
+use std::ptr;
 
+use ndarray::Dimension;
+use pyo3::{PyErr, PyNativeType, PyResult, Python};
+
+use crate::array::{PyArray, PyArrayDyn};
+use crate::dtype::Element;
 use crate::npyffi::{
     array::PY_ARRAY_API,
     npy_intp, npy_uint32,
@@ -19,28 +36,16 @@ use crate::npyffi::{
     NPY_ITER_READONLY, NPY_ITER_READWRITE, NPY_ITER_REDUCE_OK, NPY_ITER_REFS_OK,
     NPY_ITER_ZEROSIZE_OK,
 };
-use crate::{Element, PyArray, PyArrayDyn, PyReadonlyArray};
-
-use std::marker::PhantomData;
-use std::os::raw::*;
-use std::ptr;
+use crate::readonly::PyReadonlyArray;
 
 /// Flags for constructing an iterator.
-/// For the meanings of each flag, readers can refer to [the numpy document][doc].
 ///
-/// Note that this enum doesn't provide all flags in the numpy C-API.
-/// If you have any inconvenience about that, please file an [issue].
+/// The meanings of these flags are defined in the [the NumPy documentation][iterator].
 ///
-/// [doc]: https://numpy.org/doc/stable/reference/c-api/iterator.html#c.NpyIter_MultiNew
-/// [issue]: https://github.com/PyO3/rust-numpy/issues
-// Here's a list of unsupported flags:
-// CIndex,
-// FIndex,
-// MultiIndex,
-// ExternalLoop,
-// ReadWrite,
-// ReadOnly,
-// WriteOnly,
+/// Note that some flags like `MultiIndex` and `ReadOnly` are directly represented
+/// by the iterators types provided here.
+///
+/// [iterator]: https://numpy.org/doc/stable/reference/c-api/iterator.html#c.NpyIter_MultiNew
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NpyIterFlag {
     CommonDtype,
@@ -53,6 +58,13 @@ pub enum NpyIterFlag {
     DelayBufAlloc,
     DontNegateStrides,
     CopyIfOverlap,
+    // CIndex,
+    // FIndex,
+    // MultiIndex,
+    // ExternalLoop,
+    // ReadWrite,
+    // ReadOnly,
+    // WriteOnly,
 }
 
 impl NpyIterFlag {
@@ -73,7 +85,7 @@ impl NpyIterFlag {
     }
 }
 
-/// Defines IterMode and MultiIterMode.
+/// Defines the sealed traits `IterMode` and `MultiIterMode`.
 mod itermode {
     use super::*;
 
@@ -91,15 +103,14 @@ mod itermode {
         };
     }
 
-    /// A combinator type that represents the mode of an iterator
-    /// (E.g., Readonly, ReadWrite, Readonly + ReadWrite).
+    /// A combinator type that represents the mode of an iterator.
     pub trait MultiIterMode {
         private_decl!();
         type Pre: MultiIterMode;
         const FLAG: npy_uint32 = 0;
         fn flags() -> Vec<npy_uint32> {
             if Self::FLAG == 0 {
-                vec![]
+                Vec::new()
             } else {
                 let mut res = Self::Pre::flags();
                 res.push(Self::FLAG);
@@ -156,7 +167,7 @@ pub use itermode::{
     IterMode, MultiIterMode, MultiIterModeWithManyArrays, ReadWrite, Readonly, RO, RW,
 };
 
-/// Builder of [NpySingleIter](./struct.NpySingleIter.html).
+/// Builder of [`NpySingleIter`].
 pub struct NpySingleIterBuilder<'py, T, I: IterMode> {
     flags: npy_uint32,
     array: &'py PyArrayDyn<T>,
@@ -165,9 +176,10 @@ pub struct NpySingleIterBuilder<'py, T, I: IterMode> {
 }
 
 impl<'py, T: Element> NpySingleIterBuilder<'py, T, Readonly> {
-    /// Makes a new builder for a readonly iterator.
-    pub fn readonly<D: ndarray::Dimension>(array: PyReadonlyArray<'py, T, D>) -> Self {
+    /// Create a new builder for a readonly iterator.
+    pub fn readonly<D: Dimension>(array: PyReadonlyArray<'py, T, D>) -> Self {
         let (array, was_writable) = array.destruct();
+
         Self {
             flags: NPY_ITER_READONLY,
             array: array.to_dyn(),
@@ -178,13 +190,13 @@ impl<'py, T: Element> NpySingleIterBuilder<'py, T, Readonly> {
 }
 
 impl<'py, T: Element> NpySingleIterBuilder<'py, T, ReadWrite> {
-    /// Makes a new builder for a writable iterator.
+    /// Create a new builder for a writable iterator.
     ///
     /// # Safety
     ///
     /// The iterator will produce mutable references into the array which must not be
     /// aliased by other references for the life time of the iterator.
-    pub unsafe fn readwrite<D: ndarray::Dimension>(array: &'py PyArray<T, D>) -> Self {
+    pub unsafe fn readwrite<D: Dimension>(array: &'py PyArray<T, D>) -> Self {
         Self {
             flags: NPY_ITER_READWRITE,
             array: array.to_dyn(),
@@ -195,7 +207,7 @@ impl<'py, T: Element> NpySingleIterBuilder<'py, T, ReadWrite> {
 }
 
 impl<'py, T: Element, I: IterMode> NpySingleIterBuilder<'py, T, I> {
-    /// Sets a flag to this builder, returning `self`.
+    /// Applies a flag to this builder, returning `self`.
     #[must_use]
     pub fn set(mut self, flag: NpyIterFlag) -> Self {
         self.flags |= flag.to_c_enum();
@@ -206,6 +218,7 @@ impl<'py, T: Element, I: IterMode> NpySingleIterBuilder<'py, T, I> {
     pub fn build(self) -> PyResult<NpySingleIter<'py, T, I>> {
         let array_ptr = self.array.as_array_ptr();
         let py = self.array.py();
+
         let iter_ptr = unsafe {
             PY_ARRAY_API.NpyIter_New(
                 py,
@@ -216,54 +229,54 @@ impl<'py, T: Element, I: IterMode> NpySingleIterBuilder<'py, T, I> {
                 ptr::null_mut(),
             )
         };
+
         let readonly_array_ptr = if self.was_writable {
             Some(array_ptr)
         } else {
             None
         };
+
         NpySingleIter::new(iter_ptr, readonly_array_ptr, py)
     }
 }
 
-/// An iterator over a single array, construced by
-/// [NpySingleIterBuilder](./struct.NpySingleIterBuilder.html).
-/// This iterator iterates all elements in the array as `&mut T` (in case `readwrite` is used)
-/// or `&T` (in case `readonly` is used).
+/// An iterator over a single array, construced by [`NpySingleIterBuilder`].
+///
+/// The elements are access `&mut T` in case `readwrite` is used or
+/// `&T` in case `readonly` is used.
 ///
 /// # Example
 ///
-/// You can use
-/// [`NpySingleIterBuilder::readwrite`](./struct.NpySingleIterBuilder.html#method.readwrite)
-/// to get a mutable iterator.
+/// You can use [`NpySingleIterBuilder::readwrite`] to get a mutable iterator.
 ///
 /// ```
-/// use numpy::NpySingleIterBuilder;
-/// pyo3::Python::with_gil(|py| {
-///     let array = numpy::PyArray::arange(py, 0, 10, 1);
+/// use numpy::pyo3::Python;
+/// use numpy::{NpySingleIterBuilder, PyArray};
+///
+/// Python::with_gil(|py| {
+///     let array = PyArray::arange(py, 0, 10, 1);
+///
 ///     let iter = unsafe { NpySingleIterBuilder::readwrite(array).build().unwrap() };
+///
 ///     for (i, elem) in iter.enumerate() {
 ///         assert_eq!(*elem, i as i64);
-///         *elem = *elem * 2;  // elements are mutable
+///
+///         *elem = *elem * 2;  // Elements can be mutated.
 ///     }
 /// });
 /// ```
-/// Or, as a shorthand, `PyArray::iter` can be also used.
+///
+/// On the other hand, a readonly iterator requires an instance of [`PyReadonlyArray`].
+///
 /// ```
-/// # use numpy::NpySingleIterBuilder;
-/// # pyo3::Python::with_gil(|py| {
-/// #   let array = numpy::PyArray::arange(py, 0, 10, 1);
-///     for (i, elem) in unsafe { array.iter().unwrap().enumerate() } {
-///         assert_eq!(*elem, i as i64);
-///         *elem = *elem * 2;  // elements are mutable
-///     }
-/// });
-/// ```
-/// On the other hand, immutable iterator requires [readonly array](../struct.PyReadonlyArray.html).
-/// ```
-/// use numpy::NpySingleIterBuilder;
-/// pyo3::Python::with_gil(|py| {
-///     let array = numpy::PyArray::arange(py, 0, 1, 10);
+/// use numpy::pyo3::Python;
+/// use numpy::{NpySingleIterBuilder, PyArray};
+///
+/// Python::with_gil(|py| {
+///     let array = PyArray::arange(py, 0, 1, 10);
+///
 ///     let iter = NpySingleIterBuilder::readonly(array.readonly()).build().unwrap();
+///
 ///     for (i, elem) in iter.enumerate() {
 ///         assert_eq!(*elem, i as i64);
 ///     }
@@ -289,21 +302,17 @@ impl<'py, T, I> NpySingleIter<'py, T, I> {
     ) -> PyResult<Self> {
         let mut iterator = match ptr::NonNull::new(iterator) {
             Some(iter) => iter,
-            None => {
-                return Err(PyErr::fetch(py));
-            }
+            None => return Err(PyErr::fetch(py)),
         };
 
         let iternext = match unsafe {
             PY_ARRAY_API.NpyIter_GetIterNext(py, iterator.as_mut(), ptr::null_mut())
         } {
             Some(ptr) => ptr,
-            None => {
-                return Err(PyErr::fetch(py));
-            }
+            None => return Err(PyErr::fetch(py)),
         };
-        let dataptr = unsafe { PY_ARRAY_API.NpyIter_GetDataPtrArray(py, iterator.as_mut()) };
 
+        let dataptr = unsafe { PY_ARRAY_API.NpyIter_GetDataPtrArray(py, iterator.as_mut()) };
         if dataptr.is_null() {
             unsafe { PY_ARRAY_API.NpyIter_Deallocate(py, iterator.as_mut()) };
             return Err(PyErr::fetch(py));
@@ -342,6 +351,7 @@ impl<'py, T, I> NpySingleIter<'py, T, I> {
 impl<'py, T, I> Drop for NpySingleIter<'py, T, I> {
     fn drop(&mut self) {
         let _success = unsafe { PY_ARRAY_API.NpyIter_Deallocate(self.py, self.iterator.as_mut()) };
+
         if let Some(ptr) = self.readonly_array_ptr {
             unsafe {
                 (*ptr).flags |= NPY_ARRAY_WRITEABLE;
@@ -350,7 +360,7 @@ impl<'py, T, I> Drop for NpySingleIter<'py, T, I> {
     }
 }
 
-impl<'py, T: 'py> std::iter::Iterator for NpySingleIter<'py, T, Readonly> {
+impl<'py, T: 'py> Iterator for NpySingleIter<'py, T, Readonly> {
     type Item = &'py T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -362,7 +372,7 @@ impl<'py, T: 'py> std::iter::Iterator for NpySingleIter<'py, T, Readonly> {
     }
 }
 
-impl<'py, T: 'py> std::iter::Iterator for NpySingleIter<'py, T, ReadWrite> {
+impl<'py, T: 'py> Iterator for NpySingleIter<'py, T, ReadWrite> {
     type Item = &'py mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -374,7 +384,7 @@ impl<'py, T: 'py> std::iter::Iterator for NpySingleIter<'py, T, ReadWrite> {
     }
 }
 
-/// Builder for [NpyMultiIter](./struct.NpyMultiIter.html).
+/// Builder for [`NpyMultiIter`].
 pub struct NpyMultiIterBuilder<'py, T, S: MultiIterMode> {
     flags: npy_uint32,
     arrays: Vec<&'py PyArrayDyn<T>>,
@@ -399,7 +409,7 @@ impl<'py, T: Element> NpyMultiIterBuilder<'py, T, ()> {
         }
     }
 
-    /// Set a flag to this builder, returning `self`.
+    /// Applies a flag to this builder, returning `self`.
     #[must_use]
     pub fn set(mut self, flag: NpyIterFlag) -> Self {
         self.flags |= flag.to_c_enum();
@@ -409,13 +419,15 @@ impl<'py, T: Element> NpyMultiIterBuilder<'py, T, ()> {
 
 impl<'py, T: Element, S: MultiIterMode> NpyMultiIterBuilder<'py, T, S> {
     /// Add a readonly array to the resulting iterator.
-    pub fn add_readonly<D: ndarray::Dimension>(
+    pub fn add_readonly<D: Dimension>(
         mut self,
         array: PyReadonlyArray<'py, T, D>,
     ) -> NpyMultiIterBuilder<'py, T, RO<S>> {
         let (array, was_writable) = array.destruct();
+
         self.arrays.push(array.to_dyn());
         self.was_writables.push(was_writable);
+
         NpyMultiIterBuilder {
             flags: self.flags,
             arrays: self.arrays,
@@ -430,12 +442,13 @@ impl<'py, T: Element, S: MultiIterMode> NpyMultiIterBuilder<'py, T, S> {
     ///
     /// The iterator will produce mutable references into the array which must not be
     /// aliased by other references for the life time of the iterator.
-    pub unsafe fn add_readwrite<D: ndarray::Dimension>(
+    pub unsafe fn add_readwrite<D: Dimension>(
         mut self,
         array: &'py PyArray<T, D>,
     ) -> NpyMultiIterBuilder<'py, T, RW<S>> {
         self.arrays.push(array.to_dyn());
         self.was_writables.push(false);
+
         NpyMultiIterBuilder {
             flags: self.flags,
             arrays: self.arrays,
@@ -454,16 +467,15 @@ impl<'py, T: Element, S: MultiIterModeWithManyArrays> NpyMultiIterBuilder<'py, T
             was_writables,
             ..
         } = self;
-        debug_assert!(arrays.len() <= std::i32::MAX as usize);
+
+        debug_assert!(arrays.len() <= i32::MAX as usize);
         debug_assert!(2 <= arrays.len());
 
         let mut opflags = S::flags();
+
         let py = arrays[0].py();
-        let mut arrays = arrays
-            .iter()
-            .map(|x| x.as_array_ptr())
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+
+        let mut arrays = arrays.iter().map(|x| x.as_array_ptr()).collect::<Vec<_>>();
 
         let iter_ptr = unsafe {
             PY_ARRAY_API.NpyIter_MultiNew(
@@ -477,26 +489,27 @@ impl<'py, T: Element, S: MultiIterModeWithManyArrays> NpyMultiIterBuilder<'py, T
                 ptr::null_mut(),
             )
         };
+
         NpyMultiIter::new(iter_ptr, arrays, was_writables, py)
     }
 }
 
-/// An iterator over multiple arrays, construced by
-/// [NpyMultiIterBuilder](./struct.NpyMultiIterBuilder.html).
-/// You can add
-/// [`NpyMultiIterBuilder::add_readwrite`](./struct.NpyMultiIterBuilder.html#method.add_readwrite)
-/// for adding a mutable component to the iterator, and
-/// [`NpyMultiIterBuilder::add_readonly`](./struct.NpyMultiIterBuilder.html#method.add_readonly)
-/// for adding a immutable one.
+/// An iterator over multiple arrays, construced by [`NpyMultiIterBuilder`].
+///
+/// [`NpyMultiIterBuilder::add_readwrite`] is used for adding a mutable component and
+/// [`NpyMultiIterBuilder::add_readonly`] is used for adding an immutable one.
 ///
 /// # Example
 ///
 /// ```
+/// use numpy::pyo3::Python;
 /// use numpy::NpyMultiIterBuilder;
-/// pyo3::Python::with_gil(|py| {
+///
+/// Python::with_gil(|py| {
 ///     let array1 = numpy::PyArray::arange(py, 0, 10, 1);
 ///     let array2 = numpy::PyArray::arange(py, 10, 20, 1);
 ///     let array3 = numpy::PyArray::arange(py, 10, 30, 2);
+///
 ///     let iter = unsafe {
 ///         NpyMultiIterBuilder::new()
 ///             .add_readonly(array1.readonly())
@@ -505,9 +518,10 @@ impl<'py, T: Element, S: MultiIterModeWithManyArrays> NpyMultiIterBuilder<'py, T
 ///             .build()
 ///             .unwrap()
 ///     };
+///
 ///     for (i, j, k) in iter {
 ///         assert_eq!(*i + *j, *k);
-///         *j += *i + *k;  // The third element is only mutable.
+///         *j += *i + *k;  // Only the third element can be mutated.
 ///     }
 /// });
 /// ```
@@ -518,7 +532,7 @@ pub struct NpyMultiIter<'py, T, S: MultiIterModeWithManyArrays> {
     iter_size: npy_intp,
     dataptr: *mut *mut c_char,
     marker: PhantomData<(T, S)>,
-    arrays: Box<[*mut PyArrayObject]>,
+    arrays: Vec<*mut PyArrayObject>,
     was_writables: Vec<bool>,
     py: Python<'py>,
 }
@@ -526,27 +540,23 @@ pub struct NpyMultiIter<'py, T, S: MultiIterModeWithManyArrays> {
 impl<'py, T, S: MultiIterModeWithManyArrays> NpyMultiIter<'py, T, S> {
     fn new(
         iterator: *mut NpyIter,
-        arrays: Box<[*mut PyArrayObject]>,
+        arrays: Vec<*mut PyArrayObject>,
         was_writables: Vec<bool>,
         py: Python<'py>,
     ) -> PyResult<Self> {
         let mut iterator = match ptr::NonNull::new(iterator) {
             Some(ptr) => ptr,
-            None => {
-                return Err(PyErr::fetch(py));
-            }
+            None => return Err(PyErr::fetch(py)),
         };
 
         let iternext = match unsafe {
             PY_ARRAY_API.NpyIter_GetIterNext(py, iterator.as_mut(), ptr::null_mut())
         } {
             Some(ptr) => ptr,
-            None => {
-                return Err(PyErr::fetch(py));
-            }
+            None => return Err(PyErr::fetch(py)),
         };
-        let dataptr = unsafe { PY_ARRAY_API.NpyIter_GetDataPtrArray(py, iterator.as_mut()) };
 
+        let dataptr = unsafe { PY_ARRAY_API.NpyIter_GetDataPtrArray(py, iterator.as_mut()) };
         if dataptr.is_null() {
             unsafe { PY_ARRAY_API.NpyIter_Deallocate(py, iterator.as_mut()) };
             return Err(PyErr::fetch(py));
@@ -571,6 +581,7 @@ impl<'py, T, S: MultiIterModeWithManyArrays> NpyMultiIter<'py, T, S> {
 impl<'py, T, S: MultiIterModeWithManyArrays> Drop for NpyMultiIter<'py, T, S> {
     fn drop(&mut self) {
         let _success = unsafe { PY_ARRAY_API.NpyIter_Deallocate(self.py, self.iterator.as_mut()) };
+
         for (array_ptr, &was_writable) in self.arrays.iter().zip(self.was_writables.iter()) {
             if was_writable {
                 unsafe { (**array_ptr).flags |= NPY_ARRAY_WRITEABLE };
@@ -581,8 +592,9 @@ impl<'py, T, S: MultiIterModeWithManyArrays> Drop for NpyMultiIter<'py, T, S> {
 
 macro_rules! impl_multi_iter {
     ($structure: ty, $($ty: ty)+, $($ptr: ident)+, $expand: ident, $deref: expr) => {
-        impl<'py, T: 'py> std::iter::Iterator for NpyMultiIter<'py, T, $structure> {
+        impl<'py, T: 'py> Iterator for NpyMultiIter<'py, T, $structure> {
             type Item = ($($ty,)+);
+
             fn next(&mut self) -> Option<Self::Item> {
                 if self.empty {
                     None
@@ -605,7 +617,6 @@ macro_rules! impl_multi_iter {
     };
 }
 
-// Helper functions for conversion
 #[inline(always)]
 unsafe fn expand2<T>(dataptr: *mut *mut c_char) -> (*mut T, *mut T) {
     (*dataptr as *mut T, *dataptr.offset(1) as *mut T)

--- a/src/npyiter.rs
+++ b/src/npyiter.rs
@@ -3,6 +3,12 @@
 //! This module exposes two iterators:
 //! [NpySingleIter](./struct.NpySingleIter.html) and
 //! [NpyMultiIter](./struct.NpyMultiIter.html).
+#![deprecated(
+    note = "The wrappers of the array iterator API are deprecated, please use ndarray's iterators like `Lanes` and `Zip` instead."
+)]
+
+use pyo3::{prelude::*, PyNativeType};
+
 use crate::npyffi::{
     array::PY_ARRAY_API,
     npy_intp, npy_uint32,
@@ -14,7 +20,6 @@ use crate::npyffi::{
     NPY_ITER_ZEROSIZE_OK,
 };
 use crate::{Element, PyArray, PyArrayDyn, PyReadonlyArray};
-use pyo3::{prelude::*, PyNativeType};
 
 use std::marker::PhantomData;
 use std::os::raw::*;

--- a/src/readonly.rs
+++ b/src/readonly.rs
@@ -1,8 +1,11 @@
 //! Readonly arrays
-use crate::npyffi::NPY_ARRAY_WRITEABLE;
-use crate::{Element, NotContiguousError, NpyIndex, PyArray};
 use ndarray::{ArrayView, Dimension, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 use pyo3::{prelude::*, types::PyAny, AsPyPointer};
+
+use crate::npyffi::NPY_ARRAY_WRITEABLE;
+#[allow(deprecated)]
+use crate::npyiter::{NpySingleIter, NpySingleIterBuilder, Readonly};
+use crate::{Element, NotContiguousError, NpyIndex, PyArray};
 
 /// Readonly reference of [`PyArray`](../array/struct.PyArray.html).
 ///
@@ -135,8 +138,12 @@ impl<'py, T: Element, D: Dimension> PyReadonlyArray<'py, T, D> {
 
     /// Iterates all elements of this array.
     /// See [NpySingleIter](../npyiter/struct.NpySingleIter.html) for more.
-    pub fn iter(self) -> PyResult<crate::NpySingleIter<'py, T, crate::npyiter::Readonly>> {
-        crate::NpySingleIterBuilder::readonly(self).build()
+    #[deprecated(
+        note = "The wrappers of the array iterator API are deprecated, please use ndarray's `ArrayBase::iter` instead."
+    )]
+    #[allow(deprecated)]
+    pub fn iter(self) -> PyResult<NpySingleIter<'py, T, Readonly>> {
+        NpySingleIterBuilder::readonly(self).build()
     }
 
     pub(crate) fn destruct(self) -> (&'py PyArray<T, D>, bool) {

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,8 +1,8 @@
 #![allow(deprecated)]
 
 use ndarray::array;
-use numpy::{NpyMultiIterBuilder, NpySingleIterBuilder, PyArray};
-use pyo3::PyResult;
+use numpy::{pyarray, NpyMultiIterBuilder, NpySingleIterBuilder, PyArray};
+use pyo3::{PyResult, Python};
 
 macro_rules! assert_approx_eq {
     ($x: expr, $y: expr) => {
@@ -95,4 +95,49 @@ fn multiiter_rw() -> PyResult<()> {
 
         Ok(())
     })
+}
+
+#[test]
+fn single_iter_size_hint_len() {
+    Python::with_gil(|py| {
+        let arr = pyarray![py, [0, 1], [2, 3], [4, 5]];
+
+        let mut iter = NpySingleIterBuilder::readonly(arr.readonly())
+            .build()
+            .unwrap();
+
+        for len in (1..=6).rev() {
+            assert_eq!(iter.len(), len);
+            assert_eq!(iter.size_hint(), (len, Some(len)));
+            assert!(iter.next().is_some());
+        }
+
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert!(iter.next().is_none());
+    });
+}
+
+#[test]
+fn multi_iter_size_hint_len() {
+    Python::with_gil(|py| {
+        let arr1 = pyarray![py, [0, 1], [2, 3], [4, 5]];
+        let arr2 = pyarray![py, [0, 0], [0, 0], [0, 0]];
+
+        let mut iter = NpyMultiIterBuilder::new()
+            .add_readonly(arr1.readonly())
+            .add_readonly(arr2.readonly())
+            .build()
+            .unwrap();
+
+        for len in (1..=6).rev() {
+            assert_eq!(iter.len(), len);
+            assert_eq!(iter.size_hint(), (len, Some(len)));
+            assert!(iter.next().is_some());
+        }
+
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert!(iter.next().is_none());
+    });
 }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use ndarray::array;
 use numpy::{NpyMultiIterBuilder, NpySingleIterBuilder, PyArray};
 use pyo3::PyResult;


### PR DESCRIPTION
Follow-up to #279, deprecating the `npyiter` module with a short explanation of why ndarray's facilities are preferable.