### PR TITLE
Prepare to release version 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - Unreleased
+
+- v0.16.0
   - Bump PyO3 version to 0.16 ([#259](https://github.com/PyO3/rust-numpy/pull/212))
   - Support object arrays ([#216](https://github.com/PyO3/rust-numpy/pull/216))
   - Support borrowing arrays that are part of other Python objects via `PyArray::borrow_from_array` ([#230](https://github.com/PyO3/rust-numpy/pull/216))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "numpy"
-version = "0.15.1"
+version = "0.16.0"
 authors = [
     "The rust-numpy Project Developers",
     "PyO3 Project and Contributors <https://github.com/PyO3>"
 ]
-description = "Rust bindings of NumPy C-API"
+description = "PyO3-based Rust bindings of the NumPy C-API"
 documentation = "https://docs.rs/numpy"
 edition = "2018"
 rust-version = "1.48"

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.15", features = ["extension-module"] }
-numpy = "0.15"
+pyo3 = { version = "0.16", features = ["extension-module"] }
+numpy = "0.16"
 ```
 
 ```rust
@@ -93,8 +93,8 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 name = "numpy-test"
 
 [dependencies]
-pyo3 = { version = "0.15", features = ["auto-initialize"] }
-numpy = "0.15"
+pyo3 = { version = "0.16", features = ["auto-initialize"] }
+numpy = "0.16"
 ```
 
 ```rust
@@ -132,7 +132,7 @@ on anything but that exact range. It can therefore be necessary to manually unif
 For example, if you specify the following dependencies
 
 ```toml
-numpy = "0.15"
+numpy = "0.16"
 ndarray = "0.13"
 ```
 


### PR DESCRIPTION
Follow-up to #259 which also bumps our version to 0.16. However, I would like to wait doing the release until after we have decided on and possibly merged the breaking changes from #279 and #280.

