### PR TITLE
Extend our type signatures of inner and dot to match NumPy's types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Unreleased
   - Add dynamic borrow checking to safely construct references into the interior of NumPy arrays. ([#274](https://github.com/PyO3/rust-numpy/pull/274))
-  - The `inner` and `dot` functions can also return a scalar instead of a zero-dimensional array to match NumPy's types ([#285](https://github.com/PyO3/rust-numpy/pull/285))
+  - The `inner`, `dot` and `einsum` functions can also return a scalar instead of a zero-dimensional array to match NumPy's types ([#285](https://github.com/PyO3/rust-numpy/pull/285))
   - Deprecate `PyArray::from_exact_iter` after optimizing `PyArray::from_iter`. ([#292](https://github.com/PyO3/rust-numpy/pull/292))
 
 - v0.16.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Unreleased
   - Add dynamic borrow checking to safely construct references into the interior of NumPy arrays. ([#274](https://github.com/PyO3/rust-numpy/pull/274))
+  - The `inner` and `dot` functions can also return a scalar instead of a zero-dimensional array to match NumPy's types ([#285](https://github.com/PyO3/rust-numpy/pull/285))
   - Deprecate `PyArray::from_exact_iter` after optimizing `PyArray::from_iter`. ([#292](https://github.com/PyO3/rust-numpy/pull/292))
 
 - v0.16.2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,8 @@ pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::npyiter::{
     IterMode, NpyIterFlag, NpyMultiIter, NpyMultiIterBuilder, NpySingleIter, NpySingleIterBuilder,
 };
-pub use crate::sum_products::{dot, einsum_impl, inner};
+pub use crate::sum_products::{dot, einsum, inner};
+
 pub use ndarray::{array, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 
 #[cfg(doctest)]

--- a/tests/sum_products.rs
+++ b/tests/sum_products.rs
@@ -62,22 +62,22 @@ fn test_einsum() {
         let b = pyarray![py, 0, 1, 2, 3, 4];
         let c = pyarray![py, [0, 1, 2], [3, 4, 5]];
 
-        assert_eq!(einsum!("ii", a).unwrap().item(), 60);
-        assert_eq!(
-            einsum!("ii->i", a).unwrap().readonly().as_array(),
-            array![0, 6, 12, 18, 24],
-        );
-        assert_eq!(
-            einsum!("ij->i", a).unwrap().readonly().as_array(),
-            array![10, 35, 60, 85, 110],
-        );
-        assert_eq!(
-            einsum!("ji", c).unwrap().readonly().as_array(),
-            array![[0, 3], [1, 4], [2, 5]],
-        );
-        assert_eq!(
-            einsum!("ij,j", a, b).unwrap().readonly().as_array(),
-            array![30, 80, 130, 180, 230],
-        );
+        let d: &PyArray0<_> = einsum!("ii", a).unwrap();
+        assert_eq!(d.item(), 60);
+
+        let d: i32 = einsum!("ii", a).unwrap();
+        assert_eq!(d, 60);
+
+        let d: &PyArray1<_> = einsum!("ii->i", a).unwrap();
+        assert_eq!(d.readonly().as_array(), array![0, 6, 12, 18, 24]);
+
+        let d: &PyArray1<_> = einsum!("ij->i", a).unwrap();
+        assert_eq!(d.readonly().as_array(), array![10, 35, 60, 85, 110]);
+
+        let d: &PyArray2<_> = einsum!("ji", c).unwrap();
+        assert_eq!(d.readonly().as_array(), array![[0, 3], [1, 4], [2, 5]]);
+
+        let d: &PyArray1<_> = einsum!("ij,j", a, b).unwrap();
+        assert_eq!(d.readonly().as_array(), array![30, 80, 130, 180, 230]);
     });
 }

--- a/tests/sum_products.rs
+++ b/tests/sum_products.rs
@@ -1,4 +1,4 @@
-use numpy::{array, dot, einsum, inner, pyarray, Ix2, PyArray1};
+use numpy::{array, dot, einsum, inner, pyarray, PyArray0, PyArray1, PyArray2};
 use pyo3::Python;
 
 #[test]
@@ -6,11 +6,11 @@ fn test_dot() {
     Python::with_gil(|py| {
         let a = pyarray![py, [1, 0], [0, 1]];
         let b = pyarray![py, [4, 1], [2, 2]];
-        let c = dot(a, b).unwrap();
+        let c: &PyArray2<_> = dot(a, b).unwrap();
         assert_eq!(c.readonly().as_array(), array![[4, 1], [2, 2]]);
 
         let a = pyarray![py, 1, 2, 3];
-        let err = dot::<_, _, _, Ix2>(a, b).unwrap_err();
+        let err = dot::<_, _, _, &PyArray2<_>>(a, b).unwrap_err();
         assert!(err.to_string().contains("not aligned"), "{}", err);
     });
 }
@@ -20,16 +20,16 @@ fn test_inner() {
     Python::with_gil(|py| {
         let a = pyarray![py, 1, 2, 3];
         let b = pyarray![py, 0, 1, 0];
-        let c = inner(a, b).unwrap();
+        let c: &PyArray0<_> = inner(a, b).unwrap();
         assert_eq!(c.readonly().as_array(), ndarray::arr0(2));
 
         let a = pyarray![py, [1, 0], [0, 1]];
         let b = pyarray![py, [4, 1], [2, 2]];
-        let c = inner(a, b).unwrap();
+        let c: &PyArray2<_> = inner(a, b).unwrap();
         assert_eq!(c.readonly().as_array(), array![[4, 2], [1, 2]]);
 
         let a = pyarray![py, 1, 2, 3];
-        let err = inner::<_, _, _, Ix2>(a, b).unwrap_err();
+        let err = inner::<_, _, _, &PyArray2<_>>(a, b).unwrap_err();
         assert!(err.to_string().contains("not aligned"), "{}", err);
     });
 }

--- a/tests/sum_products.rs
+++ b/tests/sum_products.rs
@@ -12,6 +12,18 @@ fn test_dot() {
         let a = pyarray![py, 1, 2, 3];
         let err = dot::<_, _, _, &PyArray2<_>>(a, b).unwrap_err();
         assert!(err.to_string().contains("not aligned"), "{}", err);
+
+        let a = pyarray![py, 1, 2, 3];
+        let b = pyarray![py, 0, 1, 0];
+        let c: &PyArray0<_> = dot(a, b).unwrap();
+        assert_eq!(c.item(), 2);
+        let c: i32 = dot(a, b).unwrap();
+        assert_eq!(c, 2);
+
+        let a = pyarray![py, 1.0, 2.0, 3.0];
+        let b = pyarray![py, 0.0, 0.0, 0.0];
+        let c: f64 = dot(a, b).unwrap();
+        assert_eq!(c, 0.0);
     });
 }
 
@@ -21,7 +33,14 @@ fn test_inner() {
         let a = pyarray![py, 1, 2, 3];
         let b = pyarray![py, 0, 1, 0];
         let c: &PyArray0<_> = inner(a, b).unwrap();
-        assert_eq!(c.readonly().as_array(), ndarray::arr0(2));
+        assert_eq!(c.item(), 2);
+        let c: i32 = inner(a, b).unwrap();
+        assert_eq!(c, 2);
+
+        let a = pyarray![py, 1.0, 2.0, 3.0];
+        let b = pyarray![py, 0.0, 0.0, 0.0];
+        let c: f64 = inner(a, b).unwrap();
+        assert_eq!(c, 0.0);
 
         let a = pyarray![py, [1, 0], [0, 1]];
         let b = pyarray![py, [4, 1], [2, 2]];
@@ -43,10 +62,7 @@ fn test_einsum() {
         let b = pyarray![py, 0, 1, 2, 3, 4];
         let c = pyarray![py, [0, 1, 2], [3, 4, 5]];
 
-        assert_eq!(
-            einsum!("ii", a).unwrap().readonly().as_array(),
-            ndarray::arr0(60)
-        );
+        assert_eq!(einsum!("ii", a).unwrap().item(), 60);
         assert_eq!(
             einsum!("ii->i", a).unwrap().readonly().as_array(),
             array![0, 6, 12, 18, 24],


### PR DESCRIPTION
Closes #284 