### PR TITLE
Use the pyclass proc-macro to produce the implementation details of PySliceContainer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
 - Unreleased
+  - Fix build when PyO3's `multiple-pymethods` feature is used. ([#288](https://github.com/PyO3/rust-numpy/pull/288))
 
 - v0.16.0
-  - Bump PyO3 version to 0.16 ([#259](https://github.com/PyO3/rust-numpy/pull/212))
+  - Bump PyO3 version to 0.16 ([#259](https://github.com/PyO3/rust-numpy/pull/259))
   - Support object arrays ([#216](https://github.com/PyO3/rust-numpy/pull/216))
-  - Support borrowing arrays that are part of other Python objects via `PyArray::borrow_from_array` ([#230](https://github.com/PyO3/rust-numpy/pull/216))
+  - Support borrowing arrays that are part of other Python objects via `PyArray::borrow_from_array` ([#230](https://github.com/PyO3/rust-numpy/pull/230))
   - Fixed downcasting ignoring element type and dimensionality ([#265](https://github.com/PyO3/rust-numpy/pull/265))
   - `PyArray::new` is now `unsafe`, as it produces uninitialized arrays ([#220](https://github.com/PyO3/rust-numpy/pull/220))
   - `PyArray::iter`, `NpySingleIterBuilder::readwrite` and `NpyMultiIterBuilder::add_readwrite` are now `unsafe`, as they allow aliasing mutable references to be created ([#278/](https://github.com/PyO3/rust-numpy/pull/278))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libc = "0.2"
 num-complex = ">= 0.2, < 0.5"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
-pyo3 = { version = "0.16", default-features = false }
+pyo3 = { version = "0.16", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 pyo3 = { version = "0.16", features = ["auto-initialize"] }

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_parallel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.16", features = ["extension-module"] }
+pyo3 = { version = "0.16", features = ["extension-module", "multiple-pymethods"] }
 numpy = { path = "../.." }
 ndarray = { version = "0.15", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }

--- a/src/array.rs
+++ b/src/array.rs
@@ -121,7 +121,7 @@ unsafe impl<T: Element, D: Dimension> PyTypeInfo for PyArray<T, D> {
     type AsRefTarget = Self;
 
     const NAME: &'static str = "PyArray<T, D>";
-    const MODULE: ::std::option::Option<&'static str> = Some("numpy");
+    const MODULE: Option<&'static str> = Some("numpy");
 
     #[inline]
     fn type_object_raw(py: Python) -> *mut ffi::PyTypeObject {

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -51,7 +51,7 @@ unsafe impl PyTypeInfo for PyArrayDescr {
     type AsRefTarget = Self;
 
     const NAME: &'static str = "PyArrayDescr";
-    const MODULE: ::std::option::Option<&'static str> = Some("numpy");
+    const MODULE: Option<&'static str> = Some("numpy");
 
     #[inline]
     fn type_object_raw(py: Python) -> *mut ffi::PyTypeObject {

--- a/src/slice_container.rs
+++ b/src/slice_container.rs
@@ -1,15 +1,10 @@
 use std::{mem, slice};
 
 use ndarray::{ArrayBase, Dimension, OwnedRepr};
-use pyo3::{
-    ffi,
-    impl_::pyclass::{PyClassDummySlot, PyClassImpl, PyClassItems, ThreadCheckerStub},
-    pyclass::PyClass,
-    type_object::{LazyStaticType, PyTypeInfo},
-    PyAny, PyCell, Python,
-};
+use pyo3::pyclass;
 
 /// Utility type to safely store `Box<[_]>` or `Vec<_>` on the Python heap
+#[pyclass]
 pub(crate) struct PySliceContainer {
     ptr: *mut u8,
     len: usize,
@@ -82,34 +77,5 @@ impl Drop for PySliceContainer {
         unsafe {
             (self.drop)(self.ptr, self.len, self.cap);
         }
-    }
-}
-
-impl PyClass for PySliceContainer {
-    type Dict = PyClassDummySlot;
-    type WeakRef = PyClassDummySlot;
-    type BaseNativeType = PyAny;
-}
-
-impl PyClassImpl for PySliceContainer {
-    const DOC: &'static str = "Memory store for a PyArray backed by a Box<[_]> or a Vec<_> \0";
-
-    type BaseType = PyAny;
-    type Layout = PyCell<Self>;
-    type ThreadChecker = ThreadCheckerStub<Self>;
-
-    fn for_all_items(_visitor: &mut dyn FnMut(&PyClassItems)) {}
-}
-
-unsafe impl PyTypeInfo for PySliceContainer {
-    type AsRefTarget = PyCell<Self>;
-
-    const NAME: &'static str = "PySliceContainer";
-    const MODULE: Option<&'static str> = Some("_rust_numpy");
-
-    #[inline]
-    fn type_object_raw(py: Python) -> *mut ffi::PyTypeObject {
-        static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
-        TYPE_OBJECT.get_or_init::<Self>(py)
     }
 }


### PR DESCRIPTION
I chose to use the `pyclass` proc macro instead of trying to use features or cfgs to reduce the long-term maintenance burden as `PySliceContainer` is not special when comes to `PyClassImpl` implementors. This does mean we require PyO3's proc macros and the associated build time hit, but I suspect that the target audience using rust-numpy but not PyO3's proc macros is sufficiently limited to make this worthwhile. (I did not yet check whether there are other places in the code that could benefit from using the proc macros, but I don't expect it.)

Fixes #287 