### PR TITLE
RFC: Simplify constructors of one-dimensional arrays

### DIFF
--- a/benches/array.rs
+++ b/benches/array.rs
@@ -1,0 +1,143 @@
+#![feature(test)]
+
+extern crate test;
+use test::{black_box, Bencher};
+
+use std::ops::Range;
+
+use numpy::PyArray1;
+use pyo3::{Python, ToPyObject};
+
+struct Iter(Range<usize>);
+
+impl Iterator for Iter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+fn from_iter(bencher: &mut Bencher, size: usize) {
+    bencher.iter(|| {
+        let iter = black_box(Iter(0..size));
+
+        Python::with_gil(|py| {
+            PyArray1::from_iter(py, iter);
+        });
+    });
+}
+
+#[bench]
+fn from_iter_small(bencher: &mut Bencher) {
+    from_iter(bencher, 2_usize.pow(5));
+}
+
+#[bench]
+fn from_iter_medium(bencher: &mut Bencher) {
+    from_iter(bencher, 2_usize.pow(10));
+}
+
+#[bench]
+fn from_iter_large(bencher: &mut Bencher) {
+    from_iter(bencher, 2_usize.pow(15));
+}
+
+struct ExactIter(Range<usize>);
+
+impl Iterator for ExactIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for ExactIter {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+fn from_exact_iter(bencher: &mut Bencher, size: usize) {
+    bencher.iter(|| {
+        let iter = black_box(ExactIter(0..size));
+
+        Python::with_gil(|py| {
+            PyArray1::from_exact_iter(py, iter);
+        });
+    });
+}
+
+#[bench]
+fn from_exact_iter_small(bencher: &mut Bencher) {
+    from_exact_iter(bencher, 2_usize.pow(5));
+}
+
+#[bench]
+fn from_exact_iter_medium(bencher: &mut Bencher) {
+    from_exact_iter(bencher, 2_usize.pow(10));
+}
+
+#[bench]
+fn from_exact_iter_large(bencher: &mut Bencher) {
+    from_exact_iter(bencher, 2_usize.pow(15));
+}
+
+fn from_slice(bencher: &mut Bencher, size: usize) {
+    let vec = (0..size).collect::<Vec<_>>();
+
+    bencher.iter(|| {
+        let slice = black_box(&vec);
+
+        Python::with_gil(|py| {
+            PyArray1::from_slice(py, slice);
+        });
+    });
+}
+
+#[bench]
+fn from_slice_small(bencher: &mut Bencher) {
+    from_slice(bencher, 2_usize.pow(5));
+}
+
+#[bench]
+fn from_slice_medium(bencher: &mut Bencher) {
+    from_slice(bencher, 2_usize.pow(10));
+}
+
+#[bench]
+fn from_slice_large(bencher: &mut Bencher) {
+    from_slice(bencher, 2_usize.pow(15));
+}
+
+fn from_object_slice(bencher: &mut Bencher, size: usize) {
+    let vec = Python::with_gil(|py| (0..size).map(|val| val.to_object(py)).collect::<Vec<_>>());
+
+    bencher.iter(|| {
+        let slice = black_box(&vec);
+
+        Python::with_gil(|py| {
+            PyArray1::from_slice(py, slice);
+        });
+    });
+}
+
+#[bench]
+fn from_object_slice_small(bencher: &mut Bencher) {
+    from_object_slice(bencher, 2_usize.pow(5));
+}
+
+#[bench]
+fn from_object_slice_medium(bencher: &mut Bencher) {
+    from_object_slice(bencher, 2_usize.pow(10));
+}
+
+#[bench]
+fn from_object_slice_large(bencher: &mut Bencher) {
+    from_object_slice(bencher, 2_usize.pow(15));
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -952,18 +952,8 @@ impl<T: Element> PyArray<T, Ix1> {
     /// });
     /// ```
     pub fn from_slice<'py>(py: Python<'py>, slice: &[T]) -> &'py Self {
-        unsafe {
-            let array = PyArray::new(py, [slice.len()], false);
-            if T::IS_COPY {
-                ptr::copy_nonoverlapping(slice.as_ptr(), array.data(), slice.len());
-            } else {
-                let data_ptr = array.data();
-                for (i, item) in slice.iter().enumerate() {
-                    data_ptr.add(i).write(item.clone());
-                }
-            }
-            array
-        }
+        let data = slice.to_vec();
+        data.into_pyarray(py)
     }
 
     /// Construct one-dimension PyArray
@@ -996,20 +986,8 @@ impl<T: Element> PyArray<T, Ix1> {
     /// });
     /// ```
     pub fn from_exact_iter(py: Python<'_>, iter: impl ExactSizeIterator<Item = T>) -> &Self {
-        // NumPy will always zero-initialize object pointers,
-        // so the array can be dropped safely if the iterator panics.
-        unsafe {
-            let len = iter.len();
-            let array = Self::new(py, [len], false);
-            let mut idx = 0;
-            for item in iter {
-                assert!(idx < len);
-                array.uget_raw([idx]).write(item);
-                idx += 1;
-            }
-            assert!(idx == len);
-            array
-        }
+        let data = iter.collect::<Box<[_]>>();
+        data.into_pyarray(py)
     }
 
     /// Construct one-dimension PyArray from a type which implements
@@ -1028,29 +1006,8 @@ impl<T: Element> PyArray<T, Ix1> {
     /// });
     /// ```
     pub fn from_iter(py: Python<'_>, iter: impl IntoIterator<Item = T>) -> &Self {
-        let iter = iter.into_iter();
-        let (min_len, max_len) = iter.size_hint();
-        let mut capacity = max_len.unwrap_or_else(|| min_len.max(512 / mem::size_of::<T>()));
-        unsafe {
-            // NumPy will always zero-initialize object pointers,
-            // so the array can be dropped safely if the iterator panics.
-            let array = Self::new(py, [capacity], false);
-            let mut length = 0;
-            for (i, item) in iter.enumerate() {
-                length += 1;
-                if length > capacity {
-                    capacity *= 2;
-                    array
-                        .resize(capacity)
-                        .expect("PyArray::from_iter: Failed to allocate memory");
-                }
-                array.uget_raw([i]).write(item);
-            }
-            if capacity > length {
-                array.resize(length).unwrap()
-            }
-            array
-        }
+        let data = iter.into_iter().collect::<Vec<_>>();
+        data.into_pyarray(py)
     }
 
     /// Extends or trancates the length of 1 dimension PyArray.
@@ -1335,8 +1292,6 @@ impl<T: Element + AsPrimitive<f64>> PyArray<T, Ix1> {
 mod tests {
     use super::*;
 
-    use std::ops::Range;
-
     #[test]
     fn test_get_unchecked() {
         pyo3::Python::with_gil(|py| {
@@ -1364,38 +1319,6 @@ mod tests {
             let a = ndarray::Array2::from_shape_fn((2, 3), |(_i, _j)| PyList::empty(py).into());
             let arr: &PyArray<Py<PyAny>, _> = a.to_pyarray(py);
             py_run!(py, arr, "assert arr.dtype.hasobject");
-        });
-    }
-
-    struct InsincereIterator(Range<usize>, usize);
-
-    impl Iterator for InsincereIterator {
-        type Item = usize;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            self.0.next()
-        }
-    }
-
-    impl ExactSizeIterator for InsincereIterator {
-        fn len(&self) -> usize {
-            self.1
-        }
-    }
-
-    #[test]
-    #[should_panic]
-    fn from_exact_iter_too_short() {
-        Python::with_gil(|py| {
-            PyArray::from_exact_iter(py, InsincereIterator(0..3, 5));
-        });
-    }
-
-    #[test]
-    #[should_panic]
-    fn from_exact_iter_too_long() {
-        Python::with_gil(|py| {
-            PyArray::from_exact_iter(py, InsincereIterator(0..5, 3));
         });
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -356,10 +356,6 @@ impl<T, D> PyArray<T, D> {
         let ptr = self.as_array_ptr();
         (*ptr).data as *mut _
     }
-
-    pub(crate) unsafe fn copy_ptr(&self, other: *const T, len: usize) {
-        ptr::copy_nonoverlapping(other, self.data(), len)
-    }
 }
 
 struct InvertedAxes(u32);
@@ -959,7 +955,7 @@ impl<T: Element> PyArray<T, Ix1> {
         unsafe {
             let array = PyArray::new(py, [slice.len()], false);
             if T::IS_COPY {
-                array.copy_ptr(slice.as_ptr(), slice.len());
+                ptr::copy_nonoverlapping(slice.as_ptr(), array.data(), slice.len());
             } else {
                 let data_ptr = array.data();
                 for (i, item) in slice.iter().enumerate() {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,7 +1,7 @@
 //! Defines conversion traits between Rust types and NumPy data types.
 #![deny(missing_docs)]
 
-use std::{mem, os::raw::c_int};
+use std::{mem, os::raw::c_int, ptr};
 
 use ndarray::{ArrayBase, Data, Dimension, IntoDimension, Ix1, OwnedRepr};
 use pyo3::Python;
@@ -143,12 +143,12 @@ where
         let len = self.len();
         match self.order() {
             Some(order) if A::IS_COPY => {
-                // if the array is contiguous, copy it by `copy_ptr`.
+                // if the array is contiguous, copy it by `copy_nonoverlapping`.
                 let strides = self.npy_strides();
                 unsafe {
                     let array =
                         PyArray::new_(py, self.raw_dim(), strides.as_ptr(), order.to_flag());
-                    array.copy_ptr(self.as_ptr(), len);
+                    ptr::copy_nonoverlapping(self.as_ptr(), array.data(), len);
                     array
                 }
             }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -63,6 +63,18 @@ fn long_iter_to_pyarray() {
 }
 
 #[test]
+fn exact_iter_to_pyarray() {
+    Python::with_gil(|py| {
+        let arr = PyArray::from_exact_iter(py, 0_u32..512);
+
+        assert_eq!(
+            arr.readonly().as_slice().unwrap(),
+            (0_u32..512).collect::<Vec<_>>(),
+        );
+    });
+}
+
+#[test]
 fn from_small_array() {
     macro_rules! small_array_test {
         ($($t:ty)+) => {


### PR DESCRIPTION
This changes the constructors `PyArray::from_slice`, `PyArray::from_iter` and `PyArray::from_exact_iter` to first collect into Rust data structures like `Box<[T]>` or `Vec<T>` which are then wrapped into NumPy arrays.

This has upside of simplifying our code and removing multiple `unsafe` blocks. But it also has the downside that the resulting NumPy arrays do not natively manage their memory but have base objects which hold the Rust data structures.

I am not sure what this does to efficiency as the collection code for the Rust data structure will benefit from current and future optimizations for this from the standard library. On the other hand, this requires us to allocate an additional instance of our `PySliceContainer` on the Python heap managing the ownership of the data.