### PR TITLE
Benchmark and optimize PyArray2/3::from_vec2/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - Deprecate `PyArray::from_exact_iter` after optimizing `PyArray::from_iter`. ([#292](https://github.com/PyO3/rust-numpy/pull/292))
 
 - v0.16.2
   - Fix build on platforms where `c_char` is `u8` like Linux/AArch64. ([#296](https://github.com/PyO3/rust-numpy/pull/296))

--- a/benches/array.rs
+++ b/benches/array.rs
@@ -5,7 +5,7 @@ use test::{black_box, Bencher};
 
 use std::ops::Range;
 
-use numpy::PyArray1;
+use numpy::{PyArray1, PyArray2, PyArray3};
 use pyo3::{Python, ToPyObject};
 
 struct Iter(Range<usize>);
@@ -132,6 +132,56 @@ fn from_object_slice_medium(bencher: &mut Bencher) {
 #[bench]
 fn from_object_slice_large(bencher: &mut Bencher) {
     from_object_slice(bencher, 2_usize.pow(15));
+}
+
+fn from_vec2(bencher: &mut Bencher, size: usize) {
+    let vec2 = vec![vec![0; size]; size];
+
+    iter_with_gil(bencher, |py| {
+        let vec2 = black_box(&vec2);
+
+        PyArray2::from_vec2(py, vec2).unwrap();
+    });
+}
+
+#[bench]
+fn from_vec2_small(bencher: &mut Bencher) {
+    from_vec2(bencher, 2_usize.pow(3));
+}
+
+#[bench]
+fn from_vec2_medium(bencher: &mut Bencher) {
+    from_vec2(bencher, 2_usize.pow(5));
+}
+
+#[bench]
+fn from_vec2_large(bencher: &mut Bencher) {
+    from_vec2(bencher, 2_usize.pow(8));
+}
+
+fn from_vec3(bencher: &mut Bencher, size: usize) {
+    let vec3 = vec![vec![vec![0; size]; size]; size];
+
+    iter_with_gil(bencher, |py| {
+        let vec3 = black_box(&vec3);
+
+        PyArray3::from_vec3(py, vec3).unwrap();
+    });
+}
+
+#[bench]
+fn from_vec3_small(bencher: &mut Bencher) {
+    from_vec3(bencher, 2_usize.pow(2));
+}
+
+#[bench]
+fn from_vec3_medium(bencher: &mut Bencher) {
+    from_vec3(bencher, 2_usize.pow(4));
+}
+
+#[bench]
+fn from_vec3_large(bencher: &mut Bencher) {
+    from_vec3(bencher, 2_usize.pow(5));
 }
 
 fn iter_with_gil(bencher: &mut Bencher, mut f: impl FnMut(Python)) {

--- a/benches/array.rs
+++ b/benches/array.rs
@@ -65,6 +65,7 @@ fn from_exact_iter(bencher: &mut Bencher, size: usize) {
     iter_with_gil(bencher, |py| {
         let iter = black_box(ExactIter(0..size));
 
+        #[allow(deprecated)]
         PyArray1::from_exact_iter(py, iter);
     });
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -984,34 +984,45 @@ impl<T: Element> PyArray<T, Ix1> {
     /// # Example
     /// ```
     /// use numpy::PyArray;
-    /// use std::collections::BTreeSet;
-    /// let vec = vec![1, 2, 3, 4, 5];
-    /// pyo3::Python::with_gil(|py| {
-    ///     let pyarray = PyArray::from_exact_iter(py, vec.iter().map(|&x| x));
+    /// use pyo3::Python;
+    ///
+    /// Python::with_gil(|py| {
+    ///     let pyarray = PyArray::from_exact_iter(py, [1, 2, 3, 4, 5].into_iter().copied());
     ///     assert_eq!(pyarray.readonly().as_slice().unwrap(), &[1, 2, 3, 4, 5]);
     /// });
     /// ```
-    pub fn from_exact_iter(py: Python<'_>, iter: impl ExactSizeIterator<Item = T>) -> &Self {
-        let data = iter.collect::<Box<[_]>>();
-        data.into_pyarray(py)
+    #[deprecated(
+        note = "`from_exact_iter` is deprecated as it does not provide any benefit over `from_iter`."
+    )]
+    #[inline(always)]
+    pub fn from_exact_iter<I>(py: Python<'_>, iter: I) -> &Self
+    where
+        I: IntoIterator<Item = T>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        Self::from_iter(py, iter)
     }
 
-    /// Construct one-dimension PyArray from a type which implements
-    /// [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html).
+    /// Construct one-dimension PyArray from a type which implements [`IntoIterator`].
     ///
-    /// If no reliable [`size_hint`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.size_hint) is available,
+    /// If no reliable [`size_hint`][Iterator::size_hint] is available,
     /// this method can allocate memory multiple time, which can hurt performance.
     ///
     /// # Example
+    ///
     /// ```
     /// use numpy::PyArray;
-    /// let set: std::collections::BTreeSet<u32> = [4, 3, 2, 5, 1].into_iter().cloned().collect();
-    /// pyo3::Python::with_gil(|py| {
-    ///     let pyarray = PyArray::from_iter(py, set);
-    ///     assert_eq!(pyarray.readonly().as_slice().unwrap(), &[1, 2, 3, 4, 5]);
+    /// use pyo3::Python;
+    ///
+    /// Python::with_gil(|py| {
+    ///     let pyarray = PyArray::from_iter(py, "abcde".chars().map(u32::from));
+    ///     assert_eq!(pyarray.readonly().as_slice().unwrap(), &[97, 98, 99, 100, 101]);
     /// });
     /// ```
-    pub fn from_iter(py: Python<'_>, iter: impl IntoIterator<Item = T>) -> &Self {
+    pub fn from_iter<I>(py: Python<'_>, iter: I) -> &Self
+    where
+        I: IntoIterator<Item = T>,
+    {
         let data = iter.into_iter().collect::<Vec<_>>();
         data.into_pyarray(py)
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -1097,16 +1097,15 @@ impl<T: Element> PyArray<T, Ix2> {
     /// ```
     pub fn from_vec2<'py>(py: Python<'py>, v: &[Vec<T>]) -> Result<&'py Self, FromVecError> {
         let len2 = v.first().map_or(0, |v| v.len());
-        for v in v {
-            if v.len() != len2 {
-                return Err(FromVecError::new(v.len(), len2));
-            }
-        }
         let dims = [v.len(), len2];
+        // SAFETY: The result of `Self::new` is always safe to drop.
         unsafe {
             let array = Self::new(py, dims, false);
             let mut data_ptr = array.data();
             for v in v {
+                if v.len() != len2 {
+                    return Err(FromVecError::new(v.len(), len2));
+                }
                 if T::IS_COPY {
                     ptr::copy_nonoverlapping(v.as_ptr(), data_ptr, len2);
                     data_ptr = data_ptr.add(len2);
@@ -1144,25 +1143,20 @@ impl<T: Element> PyArray<T, Ix3> {
     /// ```
     pub fn from_vec3<'py>(py: Python<'py>, v: &[Vec<Vec<T>>]) -> Result<&'py Self, FromVecError> {
         let len2 = v.first().map_or(0, |v| v.len());
-        for v in v {
-            if v.len() != len2 {
-                return Err(FromVecError::new(v.len(), len2));
-            }
-        }
         let len3 = v.first().map_or(0, |v| v.first().map_or(0, |v| v.len()));
-        for v in v {
-            for v in v {
-                if v.len() != len3 {
-                    return Err(FromVecError::new(v.len(), len3));
-                }
-            }
-        }
         let dims = [v.len(), len2, len3];
+        // SAFETY: The result of `Self::new` is always safe to drop.
         unsafe {
             let array = Self::new(py, dims, false);
             let mut data_ptr = array.data();
             for v in v {
+                if v.len() != len2 {
+                    return Err(FromVecError::new(v.len(), len2));
+                }
                 for v in v {
+                    if v.len() != len3 {
+                        return Err(FromVecError::new(v.len(), len3));
+                    }
                     if T::IS_COPY {
                         ptr::copy_nonoverlapping(v.as_ptr(), data_ptr, len3);
                         data_ptr = data_ptr.add(len3);

--- a/src/array.rs
+++ b/src/array.rs
@@ -957,9 +957,10 @@ impl<T: Element> PyArray<T, Ix1> {
             if T::IS_COPY {
                 ptr::copy_nonoverlapping(slice.as_ptr(), array.data(), slice.len());
             } else {
-                let data_ptr = array.data();
-                for (i, item) in slice.iter().enumerate() {
-                    data_ptr.add(i).write(item.clone());
+                let mut data_ptr = array.data();
+                for item in slice {
+                    data_ptr.write(item.clone());
+                    data_ptr = data_ptr.add(1);
                 }
             }
             array

--- a/src/array.rs
+++ b/src/array.rs
@@ -19,6 +19,7 @@ use pyo3::{
     Python, ToPyObject,
 };
 
+use crate::cold;
 use crate::convert::{ArrayExt, IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 use crate::dtype::{Element, PyArrayDescr};
 use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
@@ -972,6 +973,7 @@ impl<T: Element> PyArray<T, Ix1> {
     ///     assert_eq!(pyarray.readonly().as_slice().unwrap(), &[1, 2, 3, 4, 5]);
     /// });
     /// ```
+    #[inline(always)]
     pub fn from_vec<'py>(py: Python<'py>, vec: Vec<T>) -> &'py Self {
         vec.into_pyarray(py)
     }
@@ -1097,6 +1099,7 @@ impl<T: Element> PyArray<T, Ix2> {
             let mut data_ptr = array.data();
             for v in v {
                 if v.len() != len2 {
+                    cold();
                     return Err(FromVecError::new(v.len(), len2));
                 }
                 clone_elements(v, &mut data_ptr);
@@ -1136,10 +1139,12 @@ impl<T: Element> PyArray<T, Ix3> {
             let mut data_ptr = array.data();
             for v in v {
                 if v.len() != len2 {
+                    cold();
                     return Err(FromVecError::new(v.len(), len2));
                 }
                 for v in v {
                     if v.len() != len3 {
+                        cold();
                         return Err(FromVecError::new(v.len(), len3));
                     }
                     clone_elements(v, &mut data_ptr);

--- a/src/array.rs
+++ b/src/array.rs
@@ -1095,18 +1095,20 @@ impl<T: Element> PyArray<T, Ix2> {
     /// });
     /// ```
     pub fn from_vec2<'py>(py: Python<'py>, v: &[Vec<T>]) -> Result<&'py Self, FromVecError> {
-        let last_len = v.last().map_or(0, |v| v.len());
+        let len2 = v.first().map_or(0, |v| v.len());
         for v in v {
-            if v.len() != last_len {
-                return Err(FromVecError::new(v.len(), last_len));
+            if v.len() != len2 {
+                return Err(FromVecError::new(v.len(), len2));
             }
         }
-        let dims = [v.len(), last_len];
+        let dims = [v.len(), len2];
         unsafe {
             let array = Self::new(py, dims, false);
-            for (y, vy) in v.iter().enumerate() {
-                for (x, vyx) in vy.iter().enumerate() {
-                    array.uget_raw([y, x]).write(vyx.clone());
+            let mut data_ptr = array.data();
+            for v in v {
+                for v in v {
+                    data_ptr.write(v.clone());
+                    data_ptr = data_ptr.add(1);
                 }
             }
             Ok(array)
@@ -1135,13 +1137,13 @@ impl<T: Element> PyArray<T, Ix3> {
     /// });
     /// ```
     pub fn from_vec3<'py>(py: Python<'py>, v: &[Vec<Vec<T>>]) -> Result<&'py Self, FromVecError> {
-        let len2 = v.last().map_or(0, |v| v.len());
+        let len2 = v.first().map_or(0, |v| v.len());
         for v in v {
             if v.len() != len2 {
                 return Err(FromVecError::new(v.len(), len2));
             }
         }
-        let len3 = v.last().map_or(0, |v| v.last().map_or(0, |v| v.len()));
+        let len3 = v.first().map_or(0, |v| v.first().map_or(0, |v| v.len()));
         for v in v {
             for v in v {
                 if v.len() != len3 {
@@ -1152,10 +1154,12 @@ impl<T: Element> PyArray<T, Ix3> {
         let dims = [v.len(), len2, len3];
         unsafe {
             let array = Self::new(py, dims, false);
-            for (z, vz) in v.iter().enumerate() {
-                for (y, vzy) in vz.iter().enumerate() {
-                    for (x, vzyx) in vzy.iter().enumerate() {
-                        array.uget_raw([z, y, x]).write(vzyx.clone());
+            let mut data_ptr = array.data();
+            for v in v {
+                for v in v {
+                    for v in v {
+                        data_ptr.write(v.clone());
+                        data_ptr = data_ptr.add(1);
                     }
                 }
             }

--- a/src/array.rs
+++ b/src/array.rs
@@ -1106,9 +1106,14 @@ impl<T: Element> PyArray<T, Ix2> {
             let array = Self::new(py, dims, false);
             let mut data_ptr = array.data();
             for v in v {
-                for v in v {
-                    data_ptr.write(v.clone());
-                    data_ptr = data_ptr.add(1);
+                if T::IS_COPY {
+                    ptr::copy_nonoverlapping(v.as_ptr(), data_ptr, len2);
+                    data_ptr = data_ptr.add(len2);
+                } else {
+                    for v in v {
+                        data_ptr.write(v.clone());
+                        data_ptr = data_ptr.add(1);
+                    }
                 }
             }
             Ok(array)
@@ -1157,9 +1162,14 @@ impl<T: Element> PyArray<T, Ix3> {
             let mut data_ptr = array.data();
             for v in v {
                 for v in v {
-                    for v in v {
-                        data_ptr.write(v.clone());
-                        data_ptr = data_ptr.add(1);
+                    if T::IS_COPY {
+                        ptr::copy_nonoverlapping(v.as_ptr(), data_ptr, len3);
+                        data_ptr = data_ptr.add(len3);
+                    } else {
+                        for v in v {
+                            data_ptr.write(v.clone());
+                            data_ptr = data_ptr.add(1);
+                        }
                     }
                 }
             }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -163,9 +163,10 @@ where
                 );
                 unsafe {
                     let array = PyArray::<A, _>::new_(py, dim, strides.as_ptr(), 0);
-                    let data_ptr = array.data();
-                    for (i, item) in self.iter().enumerate() {
-                        data_ptr.add(i).write(item.clone());
+                    let mut data_ptr = array.data();
+                    for item in self.iter() {
+                        data_ptr.write(item.clone());
+                        data_ptr = data_ptr.add(1);
                     }
                     array
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,10 @@ mod sealed {
     pub trait Sealed {}
 }
 
+#[cold]
+#[inline(always)]
+fn cold() {}
+
 /// Create a [`PyArray`] with one, two or three dimensions.
 ///
 /// This macro is backed by [`ndarray::array`].

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -174,34 +174,38 @@ fn is_instance() {
 #[test]
 fn from_vec2() {
     Python::with_gil(|py| {
-        let vec2 = vec![vec![1, 2, 3]; 2];
+        let pyarray = PyArray::from_vec2(py, &[vec![1, 2, 3], vec![4, 5, 6]]).unwrap();
 
-        let pyarray = PyArray::from_vec2(py, &vec2).unwrap();
-
-        assert_eq!(pyarray.readonly().as_array(), array![[1, 2, 3], [1, 2, 3]]);
+        assert_eq!(pyarray.readonly().as_array(), array![[1, 2, 3], [4, 5, 6]]);
     });
 }
 
 #[test]
 fn from_vec2_ragged() {
     Python::with_gil(|py| {
-        let pyarray = PyArray::from_vec2(py, &[vec![1], vec![2, 3]]);
+        let pyarray = PyArray::from_vec2(py, &[vec![1, 2, 3], vec![4, 5]]);
 
         let err = pyarray.unwrap_err();
-        assert_eq!(err.to_string(), "invalid length: 1, but expected 2");
+        assert_eq!(err.to_string(), "invalid length: 2, but expected 3");
     });
 }
 
 #[test]
 fn from_vec3() {
     Python::with_gil(|py| {
-        let vec3 = vec![vec![vec![1, 2]; 2]; 2];
-
-        let pyarray = PyArray::from_vec3(py, &vec3).unwrap();
+        let pyarray = PyArray::from_vec3(
+            py,
+            &[
+                vec![vec![1, 2], vec![3, 4]],
+                vec![vec![5, 6], vec![7, 8]],
+                vec![vec![9, 10], vec![11, 12]],
+            ],
+        )
+        .unwrap();
 
         assert_eq!(
             pyarray.readonly().as_array(),
-            array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]]
+            array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]]
         );
     });
 }
@@ -209,7 +213,26 @@ fn from_vec3() {
 #[test]
 fn from_vec3_ragged() {
     Python::with_gil(|py| {
-        let pyarray = PyArray::from_vec3(py, &[vec![vec![1], vec![2, 3]]]);
+        let pyarray = PyArray::from_vec3(
+            py,
+            &[
+                vec![vec![1, 2], vec![3, 4]],
+                vec![vec![5, 6], vec![7, 8]],
+                vec![vec![9, 10], vec![11]],
+            ],
+        );
+
+        let err = pyarray.unwrap_err();
+        assert_eq!(err.to_string(), "invalid length: 1, but expected 2");
+
+        let pyarray = PyArray::from_vec3(
+            py,
+            &[
+                vec![vec![1, 2], vec![3, 4]],
+                vec![vec![5, 6], vec![7, 8]],
+                vec![vec![9, 10]],
+            ],
+        );
 
         let err = pyarray.unwrap_err();
         assert_eq!(err.to_string(), "invalid length: 1, but expected 2");

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -461,12 +461,31 @@ fn to_owned_works() {
 
 #[test]
 fn copy_to_works() {
-    pyo3::Python::with_gil(|py| {
+    Python::with_gil(|py| {
         let arr1 = PyArray::arange(py, 2.0, 5.0, 1.0);
         let arr2 = unsafe { PyArray::<i64, _>::new(py, [3], false) };
 
         arr1.copy_to(arr2).unwrap();
 
         assert_eq!(arr2.readonly().as_slice().unwrap(), &[2, 3, 4]);
+    });
+}
+
+#[test]
+fn get_works() {
+    Python::with_gil(|py| {
+        let array = pyarray![py, [[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]];
+
+        unsafe {
+            assert_eq!(array.get([0, 0, 0]), Some(&1));
+            assert_eq!(array.get([2, 1, 1]), Some(&12));
+            assert_eq!(array.get([0, 0, 2]), None);
+            assert_eq!(array.get([0, 2, 0]), None);
+            assert_eq!(array.get([3, 0, 0]), None);
+
+            assert_eq!(*array.uget([1, 0, 0]), 5);
+            assert_eq!(*array.uget_mut([0, 1, 0]), 3);
+            assert_eq!(*array.uget_raw([0, 0, 1]), 2);
+        }
     });
 }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -65,6 +65,7 @@ fn long_iter_to_pyarray() {
 #[test]
 fn exact_iter_to_pyarray() {
     Python::with_gil(|py| {
+        #[allow(deprecated)]
         let arr = PyArray::from_exact_iter(py, 0_u32..512);
 
         assert_eq!(

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -20,6 +20,16 @@ fn to_pyarray_vec() {
 }
 
 #[test]
+fn to_pyarray_boxed_slice() {
+    Python::with_gil(|py| {
+        let arr = vec![1, 2, 3].into_boxed_slice().to_pyarray(py);
+
+        assert_eq!(arr.shape(), [3]);
+        assert_eq!(arr.readonly().as_slice().unwrap(), &[1, 2, 3])
+    });
+}
+
+#[test]
 fn to_pyarray_array() {
     Python::with_gil(|py| {
         let arr = Array3::<f64>::zeros((3, 4, 2));
@@ -31,7 +41,7 @@ fn to_pyarray_array() {
             .map(|dim| dim * size_of::<f64>() as isize)
             .collect::<Vec<_>>();
 
-        let py_arr = arr.to_pyarray(py);
+        let py_arr = PyArray::from_array(py, &arr);
 
         assert_eq!(py_arr.shape(), shape.as_slice());
         assert_eq!(py_arr.strides(), strides.as_slice());
@@ -113,6 +123,15 @@ fn usize_dtype() {
 fn into_pyarray_vec() {
     Python::with_gil(|py| {
         let arr = vec![1, 2, 3].into_pyarray(py);
+
+        assert_eq!(arr.readonly().as_slice().unwrap(), &[1, 2, 3])
+    });
+}
+
+#[test]
+fn into_pyarray_boxed_slice() {
+    Python::with_gil(|py| {
+        let arr = vec![1, 2, 3].into_boxed_slice().into_pyarray(py);
 
         assert_eq!(arr.readonly().as_slice().unwrap(), &[1, 2, 3])
     });


### PR DESCRIPTION
Follow-up to #291. Admittedly, performance conscious code will probably try to avoid these methods, but it is relatively straight-forward to optimize them, as using pointer traversal instead of indexing brings a large improvement
```
 name              main ns/iter  indexing ns/iter  diff ns/iter   diff %  speedup 
 from_vec2_large   435,855       10,061                -425,794  -97.69%  x 43.32 
 from_vec2_medium  6,699         507                     -6,192  -92.43%  x 13.21 
 from_vec2_small   702           325                       -377  -53.70%   x 2.16 
 from_vec3_large   303,579       7,109                 -296,470  -97.66%  x 42.70 
 from_vec3_medium  38,732        3,000                  -35,732  -92.25%  x 12.91 
 from_vec3_small   950           410                       -540  -56.84%   x 2.32 
```
and optimizing for `T::IS_COPY` elements is then a bit of a mixed bag on top of this
```
 name              indexing ns/iter  copying ns/iter  diff ns/iter   diff %  speedup 
 from_vec2_large   10,061            10,265                    204    2.03%   x 0.98 
 from_vec2_medium  507               527                        20    3.94%   x 0.96 
 from_vec2_small   325               317                        -8   -2.46%   x 1.03 
 from_vec3_large   7,109             7,084                     -25   -0.35%   x 1.00 
 from_vec3_medium  3,000             1,735                  -1,265  -42.17%   x 1.73 
 from_vec3_small   410               404                        -6   -1.46%   x 1.01 
```

I suspect that this is due to the innermost slices being too short for the overhead of calling `ptr::copy_nonoverlapping` to amortize itself, but I think we can still keep as it not making things significantly worse and might help in specific cases of large rows and should not add code bloat due to `T::IS_COPY` being resolved at compile time.