### PR TITLE
Since npy_char is c_char which can be u8 or i8, we cannot unconditionally use negation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - Fix build on platforms where `c_char` is `u8` like Linux/AArch64. ([#296](https://github.com/PyO3/rust-numpy/pull/296))
 
 - v0.16.1
   - Fix build when PyO3's `multiple-pymethods` feature is used. ([#288](https://github.com/PyO3/rust-numpy/pull/288))

--- a/src/npyffi/flags.rs
+++ b/src/npyffi/flags.rs
@@ -71,7 +71,8 @@ pub const NPY_NEEDS_INIT: npy_char = 0x08;
 pub const NPY_NEEDS_PYAPI: npy_char = 0x10;
 pub const NPY_USE_GETITEM: npy_char = 0x20;
 pub const NPY_USE_SETITEM: npy_char = 0x40;
-pub const NPY_ALIGNED_STRUCT: npy_char = -128; // 0x80
+#[allow(overflowing_literals)]
+pub const NPY_ALIGNED_STRUCT: npy_char = 0x80;
 pub const NPY_FROM_FIELDS: npy_char =
     NPY_NEEDS_INIT | NPY_LIST_PICKLE | NPY_ITEM_REFCOUNT | NPY_NEEDS_PYAPI;
 pub const NPY_OBJECT_DTYPE_FLAGS: npy_char = NPY_LIST_PICKLE


### PR DESCRIPTION
Closes #295 