### PR TITLE
Refine dynamic borrow checking to track data ranges.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "BSD-2-Clause"
 [dependencies]
 libc = "0.2"
 num-complex = ">= 0.2, < 0.5"
+num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
 pyo3 = { version = "0.16", default-features = false, features = ["macros"] }

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -45,6 +45,17 @@ fn exclusive_and_shared_borrows() {
 
 #[test]
 #[should_panic(expected = "AlreadyBorrowed")]
+fn shared_and_exclusive_borrows() {
+    Python::with_gil(|py| {
+        let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
+
+        let _shared = array.readonly();
+        let _exclusive = array.readwrite();
+    });
+}
+
+#[test]
+#[should_panic(expected = "AlreadyBorrowed")]
 fn multiple_exclusive_borrows() {
     Python::with_gil(|py| {
         let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
@@ -184,7 +195,33 @@ fn non_overlapping_views_do_not_conflict() {
 
 #[test]
 #[should_panic(expected = "AlreadyBorrowed")]
-fn conflict_due_reborrow_of_overlapping_views() {
+fn conflict_due_to_overlapping_views() {
+    Python::with_gil(|py| {
+        let array = PyArray::<f64, _>::zeros(py, 3, false);
+        let locals = [("array", array)].into_py_dict(py);
+
+        let view1 = py
+            .eval("array[0:2]", None, Some(locals))
+            .unwrap()
+            .downcast::<PyArray1<f64>>()
+            .unwrap();
+        assert_eq!(view1.shape(), [2]);
+
+        let view2 = py
+            .eval("array[1:3]", None, Some(locals))
+            .unwrap()
+            .downcast::<PyArray1<f64>>()
+            .unwrap();
+        assert_eq!(view2.shape(), [2]);
+
+        let _exclusive1 = view1.readwrite();
+        let _shared2 = view2.readonly();
+    });
+}
+
+#[test]
+#[should_panic(expected = "AlreadyBorrowed")]
+fn conflict_due_to_reborrow_of_overlapping_views() {
     Python::with_gil(|py| {
         let array = PyArray::<f64, _>::zeros(py, 3, false);
         let locals = [("array", array)].into_py_dict(py);

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -155,8 +155,7 @@ fn overlapping_views_conflict() {
 }
 
 #[test]
-#[should_panic(expected = "AlreadyBorrowed")]
-fn non_overlapping_views_conflict() {
+fn non_overlapping_views_do_not_conflict() {
     Python::with_gil(|py| {
         let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
         let locals = [("array", array)].into_py_dict(py);
@@ -175,8 +174,40 @@ fn non_overlapping_views_conflict() {
             .unwrap();
         assert_eq!(view2.shape(), [1]);
 
+        let exclusive1 = view1.readwrite();
+        let exclusive2 = view2.readwrite();
+
+        assert_eq!(exclusive2.len(), 1);
+        assert_eq!(exclusive1.len(), 1);
+    });
+}
+
+#[test]
+#[should_panic(expected = "AlreadyBorrowed")]
+fn conflict_due_reborrow_of_overlapping_views() {
+    Python::with_gil(|py| {
+        let array = PyArray::<f64, _>::zeros(py, 3, false);
+        let locals = [("array", array)].into_py_dict(py);
+
+        let view1 = py
+            .eval("array[0:2]", None, Some(locals))
+            .unwrap()
+            .downcast::<PyArray1<f64>>()
+            .unwrap();
+        assert_eq!(view1.shape(), [2]);
+
+        let view2 = py
+            .eval("array[1:3]", None, Some(locals))
+            .unwrap()
+            .downcast::<PyArray1<f64>>()
+            .unwrap();
+        assert_eq!(view2.shape(), [2]);
+
+        let shared1 = view1.readonly();
+        let _shared2 = view2.readonly();
+
+        drop(shared1);
         let _exclusive1 = view1.readwrite();
-        let _exclusive2 = view2.readwrite();
     });
 }
 


### PR DESCRIPTION
Follow-up to #274 as discussed in https://github.com/PyO3/rust-numpy/pull/274#issuecomment-1071048638. Should show that this can work, but still needs needs many unit tests to drive the range data structures into various stages...