### PR TITLE
Add xtask Python script to automate recurring development tasks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,7 @@ jobs:
           default: true
       - uses: Swatinem/rust-cache@v1
         continue-on-error: true
-      - run: |
-          cargo fmt --all -- --check
-          cargo clippy --workspace --tests -- --deny warnings
+      - run: ./x.py check
 
   test:
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }}


### PR DESCRIPTION
Not to be totally outdone by PyO3 which has not one but two methods to do this, adds a script to automate the most common tasks and thereby simplify things for new contributors and streamline work for the old hands.