### PR TITLE
Fixes and refinements to dynamic borrow checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Unreleased
   - Add dynamic borrow checking to safely construct references into the interior of NumPy arrays. ([#274](https://github.com/PyO3/rust-numpy/pull/274))
+    - The deprecated iterator builders `NpySingleIterBuilder::{readonly,readwrite}` and `NpyMultiIterBuilder::add_{readonly,readwrite}` now take referencces to `PyReadonlyArray` and `PyReadwriteArray` instead of consuming them.
+    - The destructive `PyArray::resize` method is now unsafe if used without an instance of `PyReadwriteArray`. ([#302](https://github.com/PyO3/rust-numpy/pull/302))
   - The `inner`, `dot` and `einsum` functions can also return a scalar instead of a zero-dimensional array to match NumPy's types ([#285](https://github.com/PyO3/rust-numpy/pull/285))
   - Deprecate `PyArray::from_exact_iter` after optimizing `PyArray::from_iter`. ([#292](https://github.com/PyO3/rust-numpy/pull/292))
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -1077,19 +1077,30 @@ impl<T: Element> PyArray<T, Ix1> {
         data.into_pyarray(py)
     }
 
-    /// Extends or trancates the length of 1 dimension PyArray.
+    /// Extends or truncates the length of a one-dimensional array.
+    ///
+    /// # Safety
+    ///
+    /// There should be no outstanding references (shared or exclusive) into the array
+    /// as this method might re-allocate it and thereby invalidate all pointers into it.
     ///
     /// # Example
+    ///
     /// ```
     /// use numpy::PyArray;
-    /// pyo3::Python::with_gil(|py| {
+    /// use pyo3::Python;
+    ///
+    /// Python::with_gil(|py| {
     ///     let pyarray = PyArray::arange(py, 0, 10, 1);
     ///     assert_eq!(pyarray.len(), 10);
-    ///     pyarray.resize(100).unwrap();
+    ///
+    ///     unsafe {
+    ///         pyarray.resize(100).unwrap();
+    ///     }
     ///     assert_eq!(pyarray.len(), 100);
     /// });
     /// ```
-    pub fn resize(&self, new_elems: usize) -> PyResult<()> {
+    pub unsafe fn resize(&self, new_elems: usize) -> PyResult<()> {
         self.resize_(self.py(), [new_elems], 1, NPY_ORDER::NPY_ANYORDER)
     }
 

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -275,6 +275,16 @@ where
     }
 }
 
+impl<'a, T, D> Clone for PyReadonlyArray<'a, T, D>
+where
+    T: Element,
+    D: Dimension,
+{
+    fn clone(&self) -> Self {
+        Self::try_new(self.0).unwrap()
+    }
+}
+
 impl<'a, T, D> Drop for PyReadonlyArray<'a, T, D> {
     fn drop(&mut self) {
         let address = base_address(self.0);

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -29,7 +29,9 @@ use crate::sealed::Sealed;
 ///     assert_eq!(py_array.readonly().as_slice().unwrap(), &[1, 2, 3]);
 ///
 ///     // Array cannot be resized when its data is owned by Rust.
-///     assert!(py_array.resize(100).is_err());
+///     unsafe {
+///         assert!(py_array.resize(100).is_err());
+///     }
 /// });
 /// ```
 pub trait IntoPyArray {

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -248,3 +248,17 @@ fn readwrite_as_array_slice() {
         assert_eq!(*array.get_mut([0, 1, 2]).unwrap(), 0.0);
     });
 }
+
+#[test]
+fn resize_using_exclusive_borrow() {
+    Python::with_gil(|py| {
+        let array = PyArray::<f64, _>::zeros(py, 3, false);
+        assert_eq!(array.shape(), [3]);
+
+        let mut array = array.readwrite();
+        assert_eq!(array.as_slice_mut().unwrap(), &[0.0; 3]);
+
+        let mut array = array.resize(5).unwrap();
+        assert_eq!(array.as_slice_mut().unwrap(), &[0.0; 5]);
+    });
+}

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -116,6 +116,19 @@ fn borrows_span_threads() {
 }
 
 #[test]
+fn shared_borrows_can_be_cloned() {
+    Python::with_gil(|py| {
+        let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
+
+        let shared1 = array.readonly();
+        let shared2 = shared1.clone();
+
+        assert_eq!(shared2.shape(), [1, 2, 3]);
+        assert_eq!(shared1.shape(), [1, 2, 3]);
+    });
+}
+
+#[test]
 #[should_panic(expected = "AlreadyBorrowed")]
 fn overlapping_views_conflict() {
     Python::with_gil(|py| {

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -161,7 +161,9 @@ fn into_pyarray_cannot_resize() {
     Python::with_gil(|py| {
         let arr = vec![1, 2, 3].into_pyarray(py);
 
-        assert!(arr.resize(100).is_err())
+        unsafe {
+            assert!(arr.resize(100).is_err());
+        }
     });
 }
 


### PR DESCRIPTION
The thing here is making `PyArray::resize` unsafe as it may reallocate the array in-place thereby invalidate all existing pointers into its interior. The safe replacement is `PyReadwriteArray::resize` which will release and re-acquire an exclusive borrow of the array.

Does anybody now of other "destructive" methods which would need the same treatment?

I think was arguably unsound for the previous `PyReadonlyArray` as well as the following appears to work:
```rust
use numpy::{npyffi::NPY_ARRAY_WRITEABLE, PyArray};
use pyo3::Python;

Python::with_gil(|py| {
    let pyarray = PyArray::arange(py, 0, 10, 1);
    assert_eq!(pyarray.len(), 10);

    unsafe {
        (*pyarray.as_array_ptr()).flags &= !NPY_ARRAY_WRITEABLE;
        pyarray.resize(100).unwrap();
    }
    assert_eq!(pyarray.len(), 100);
});
```