### PR TITLE
Fix returning invalid strides and dimensions for rank zero arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - Fix returning invalid slices from `PyArray::{strides,shape}` for rank zero arrays. ([#303](https://github.com/PyO3/rust-numpy/pull/303))
 
 - v0.16.2
   - Fix build on platforms where `c_char` is `u8` like Linux/AArch64. ([#296](https://github.com/PyO3/rust-numpy/pull/296))

--- a/src/array.rs
+++ b/src/array.rs
@@ -19,6 +19,7 @@ use pyo3::{
     Python, ToPyObject,
 };
 
+use crate::cold;
 use crate::convert::{ArrayExt, IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 use crate::dtype::{Element, PyArrayDescr};
 use crate::error::{DimensionalityError, FromVecError, NotContiguousError, TypeError};
@@ -314,6 +315,10 @@ impl<T, D> PyArray<T, D> {
     // C API: https://numpy.org/doc/stable/reference/c-api/array.html#c.PyArray_STRIDES
     pub fn strides(&self) -> &[isize] {
         let n = self.ndim();
+        if n == 0 {
+            cold();
+            return &[];
+        }
         let ptr = self.as_array_ptr();
         unsafe {
             let p = (*ptr).strides;
@@ -335,6 +340,10 @@ impl<T, D> PyArray<T, D> {
     // C API: https://numpy.org/doc/stable/reference/c-api/array.html#c.PyArray_DIMS
     pub fn shape(&self) -> &[usize] {
         let n = self.ndim();
+        if n == 0 {
+            cold();
+            return &[];
+        }
         let ptr = self.as_array_ptr();
         unsafe {
             let p = (*ptr).dimensions as *mut usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,10 @@ mod doctest {
     doc_comment!(include_str!("../README.md"), readme);
 }
 
+#[cold]
+#[inline(always)]
+fn cold() {}
+
 /// Create a [`PyArray`] with one, two or three dimensions.
 ///
 /// This macro is backed by [`ndarray::array`].

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -69,6 +69,17 @@ fn tuple_as_dim() {
 }
 
 #[test]
+fn rank_zero_array_has_invalid_strides_dimensions() {
+    Python::with_gil(|py| {
+        let arr = PyArray::<f64, _>::zeros(py, (), false);
+
+        assert_eq!(arr.ndim(), 0);
+        assert_eq!(arr.strides(), &[]);
+        assert_eq!(arr.shape(), &[]);
+    })
+}
+
+#[test]
 fn zeros() {
     Python::with_gil(|py| {
         let dims = [3, 4];


### PR DESCRIPTION
[The docs](https://numpy.org/doc/stable/reference/c-api/types-and-structures.html#c.NPY_AO.nd) contain:

> When nd is 0, the array is sometimes called a rank-0 array. Such arrays have undefined dimensions and strides and cannot be accessed.