### PR TITLE
Collect scattered code for converting strides

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -144,12 +144,11 @@ where
     fn to_pyarray<'py>(&self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         let len = self.len();
         match self.order() {
-            Some(order) if A::IS_COPY => {
+            Some(flag) if A::IS_COPY => {
                 // if the array is contiguous, copy it by `copy_nonoverlapping`.
                 let strides = self.npy_strides();
                 unsafe {
-                    let array =
-                        PyArray::new_(py, self.raw_dim(), strides.as_ptr(), order.to_flag());
+                    let array = PyArray::new_(py, self.raw_dim(), strides.as_ptr(), flag);
                     ptr::copy_nonoverlapping(self.as_ptr(), array.data(), len);
                     array
                 }
@@ -157,14 +156,8 @@ where
             _ => {
                 // if the array is not contiguous, copy all elements by `ArrayBase::iter`.
                 let dim = self.raw_dim();
-                let strides = NpyStrides::new::<_, A>(
-                    dim.default_strides()
-                        .slice()
-                        .iter()
-                        .map(|&x| x as npyffi::npy_intp),
-                );
                 unsafe {
-                    let array = PyArray::<A, _>::new_(py, dim, strides.as_ptr(), 0);
+                    let array = PyArray::<A, _>::new(py, dim, false);
                     let mut data_ptr = array.data();
                     for item in self.iter() {
                         data_ptr.write(item.clone());
@@ -177,23 +170,9 @@ where
     }
 }
 
-pub(crate) enum Order {
-    Standard,
-    Fortran,
-}
-
-impl Order {
-    fn to_flag(&self) -> c_int {
-        match self {
-            Order::Standard => 0,
-            Order::Fortran => 1,
-        }
-    }
-}
-
 pub(crate) trait ArrayExt {
-    fn npy_strides(&self) -> NpyStrides;
-    fn order(&self) -> Option<Order>;
+    fn npy_strides(&self) -> [npyffi::npy_intp; 32];
+    fn order(&self) -> Option<c_int>;
 }
 
 impl<A, S, D> ArrayExt for ArrayBase<S, D>
@@ -201,42 +180,32 @@ where
     S: Data<Elem = A>,
     D: Dimension,
 {
-    fn npy_strides(&self) -> NpyStrides {
-        NpyStrides::new::<_, A>(self.strides().iter().map(|&x| x as npyffi::npy_intp))
+    fn npy_strides(&self) -> [npyffi::npy_intp; 32] {
+        let strides = self.strides();
+        let itemsize = mem::size_of::<A>() as isize;
+
+        assert!(
+            strides.len() <= 32,
+            "Only dimensionalities of up to 32 are supported"
+        );
+
+        let mut new_strides = [0; 32];
+
+        for i in 0..strides.len() {
+            new_strides[i] = (strides[i] * itemsize) as npyffi::npy_intp;
+        }
+
+        new_strides
     }
 
-    fn order(&self) -> Option<Order> {
+    fn order(&self) -> Option<c_int> {
         if self.is_standard_layout() {
-            Some(Order::Standard)
+            Some(npyffi::NPY_ORDER::NPY_CORDER as _)
         } else if self.ndim() > 1 && self.raw_view().reversed_axes().is_standard_layout() {
-            Some(Order::Fortran)
+            Some(npyffi::NPY_ORDER::NPY_FORTRANORDER as _)
         } else {
             None
         }
-    }
-}
-
-/// An array of strides sufficiently large for [any NumPy array][NPY_MAXDIMS]
-///
-/// [NPY_MAXDIMS]: https://github.com/numpy/numpy/blob/4c60b3263ac50e5e72f6a909e156314fc3c9cba0/numpy/core/include/numpy/ndarraytypes.h#L40
-pub(crate) struct NpyStrides([npyffi::npy_intp; 32]);
-
-impl NpyStrides {
-    pub(crate) fn as_ptr(&self) -> *const npy_intp {
-        self.0.as_ptr()
-    }
-
-    fn new<S, A>(strides: S) -> Self
-    where
-        S: Iterator<Item = npyffi::npy_intp>,
-    {
-        let type_size = mem::size_of::<A>() as npyffi::npy_intp;
-        let mut res = [0; 32];
-        for (i, s) in strides.enumerate() {
-            *res.get_mut(i)
-                .expect("Only dimensionalities of up to 32 are supported") = s * type_size;
-        }
-        Self(res)
     }
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -90,6 +90,11 @@ fn rank_zero_array_has_invalid_strides_dimensions() {
         assert_eq!(arr.ndim(), 0);
         assert_eq!(arr.strides(), &[]);
         assert_eq!(arr.shape(), &[]);
+
+        assert_eq!(arr.len(), 1);
+        assert!(!arr.is_empty());
+
+        assert_eq!(arr.item(), 0.0);
     })
 }
 


### PR DESCRIPTION
This mainly collects the code that is necessary to convert strides between NumPy's byte-unit convention and ndarray's item-unit convention which was scattered over multiple small helper types with the aim of making it easier to follow. 