### PR TITLE
Copy-edit the array module.

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -148,7 +148,7 @@ where
                 // if the array is contiguous, copy it by `copy_nonoverlapping`.
                 let strides = self.npy_strides();
                 unsafe {
-                    let array = PyArray::new_(py, self.raw_dim(), strides.as_ptr(), flag);
+                    let array = PyArray::new_uninit(py, self.raw_dim(), strides.as_ptr(), flag);
                     ptr::copy_nonoverlapping(self.as_ptr(), array.data(), len);
                     array
                 }

--- a/x.py
+++ b/x.py
@@ -121,9 +121,13 @@ def format_(args):
 
 def prune(args):
     shutil.rmtree("target", ignore_errors=True)
+    Path("Cargo.lock").unlink(missing_ok=True)
 
     for target_dir in gen_examples("target"):
         shutil.rmtree(target_dir, ignore_errors=True)
+
+    for lock_file in gen_examples("Cargo.lock"):
+        lock_file.unlink(missing_ok=True)
 
     for nox_dir in gen_examples(".nox"):
         shutil.rmtree(nox_dir, ignore_errors=True)


### PR DESCRIPTION
No major changes but multiple fixes to the wording, but also the contents (e.g. mixed up safety properties or incorrect links) of the documentation. Small improvement to the `FromPyObject` implementation (checking dimensionality before element type because that is faster). Made `PyArray::data` public as it seem strange to expose `PyArray::as_array_ptr` but not that one.