### PR TITLE
Delay formatting type errors to improve performance of failed extractions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - The `inner`, `dot` and `einsum` functions can also return a scalar instead of a zero-dimensional array to match NumPy's types ([#285](https://github.com/PyO3/rust-numpy/pull/285))
   - The `PyArray::resize` function supports n-dimensional contiguous arrays. ([#312](https://github.com/PyO3/rust-numpy/pull/312))
   - Deprecate `PyArray::from_exact_iter` after optimizing `PyArray::from_iter`. ([#292](https://github.com/PyO3/rust-numpy/pull/292))
+  - Remove `DimensionalityError` and `TypeError` from the public API as they never used directly. ([#315](https://github.com/PyO3/rust-numpy/pull/315))
   - Fix returning invalid slices from `PyArray::{strides,shape}` for rank zero arrays. ([#303](https://github.com/PyO3/rust-numpy/pull/303))
 
 - v0.16.2

--- a/benches/array.rs
+++ b/benches/array.rs
@@ -6,7 +6,29 @@ use test::{black_box, Bencher};
 use std::ops::Range;
 
 use numpy::{PyArray1, PyArray2, PyArray3};
-use pyo3::{Python, ToPyObject};
+use pyo3::{PyAny, Python, ToPyObject};
+
+#[bench]
+fn extract_success(bencher: &mut Bencher) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyArray2::<f64>::zeros(py, (10, 10), false);
+
+        bencher.iter(|| {
+            black_box(any).extract::<&PyArray2<f64>>().unwrap();
+        });
+    });
+}
+
+#[bench]
+fn extract_failure(bencher: &mut Bencher) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyArray2::<i32>::zeros(py, (10, 10), false);
+
+        bencher.iter(|| {
+            black_box(any).extract::<&PyArray2<f64>>().unwrap_err();
+        });
+    });
+}
 
 struct Iter(Range<usize>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,7 @@ pub use crate::borrow::{
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 pub use crate::dtype::{dtype, Complex32, Complex64, Element, PyArrayDescr};
-pub use crate::error::{
-    BorrowError, DimensionalityError, FromVecError, NotContiguousError, TypeError,
-};
+pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 #[allow(deprecated)]
 pub use crate::npyiter::{


### PR DESCRIPTION
This should be especially useful for functions that accept several element types like what was discussed in #289. Even more so, as `rust-numpy` implements `PyTypeInfo::is_type_of` in terms of `FromPyObject::extract`.

The benchmark results seem to justify the manual implementation of `PyErrArguments`: 

```
name             main ns/iter  pr ns/iter  diff ns/iter   diff %   speedup 
extract_failure  13,326        90               -13,236  -99.32%  x 148.07 
extract_success  20            19                    -1   -5.00%    x 1.05 
```