### PR TITLE
Break examples out of main workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           import toml
           cargo_toml = toml.load("Cargo.toml")
-          cargo_toml["workspace"]["resolver"] = "2"
+          cargo_toml["package"]["resolver"] = "2"
           with open("Cargo.toml", "w") as f:
             toml.dump(cargo_toml, f)
         shell: python
@@ -116,14 +116,13 @@ jobs:
         continue-on-error: true
       - name: Install toml
         run: pip install toml
-      - name: Edit Cargo.toml and detach from workspace
+      - name: Edit Cargo.toml
         run: |
           import toml
           cargo_toml = toml.load("Cargo.toml")
           cargo_toml["dependencies"]["ndarray"] = "0.13.1"
           cargo_toml["dependencies"]["parking_lot"] = "0.11.2"
           cargo_toml["dependencies"]["num-complex"] = "0.2.4"
-          cargo_toml["workspace"] = {}
           with open("Cargo.toml", "w") as f:
             toml.dump(cargo_toml, f)
         working-directory: examples/simple

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,5 @@ pyo3 = { version = "0.16", default-features = false, features = ["macros"] }
 [dev-dependencies]
 pyo3 = { version = "0.16", default-features = false, features = ["auto-initialize"] }
 
-[workspace]
-members = ["examples/*"]
-
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -12,3 +12,5 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.16", features = ["extension-module"] }
 numpy = { path = "../.." }
 ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
+
+[workspace]

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -14,3 +14,5 @@ numpy = { path = "../.." }
 ndarray = { version = "0.15", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }
 openblas-src = { version = "0.10", features = ["cblas", "system"] }
+
+[workspace]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -11,3 +11,5 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.16", features = ["extension-module", "abi3-py37"] }
 numpy = { path = "../.." }
+
+[workspace]


### PR DESCRIPTION
As features are unified over the whole of a workspace, having the examples inside the main workspace prevents independent tests of different combinations of PyO3 features. Therefore, this PR breaks them out into separate workspaces and adjust the xtask script to still include them where appropriate.