### PR TITLE
Avoid the overhead of creating a PyErr for downcasting.

### DIFF
--- a/benches/array.rs
+++ b/benches/array.rs
@@ -30,6 +30,27 @@ fn extract_failure(bencher: &mut Bencher) {
     });
 }
 
+#[bench]
+fn downcast_success(bencher: &mut Bencher) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyArray2::<f64>::zeros(py, (10, 10), false);
+
+        bencher.iter(|| {
+            black_box(any).downcast::<PyArray2<f64>>().unwrap();
+        });
+    });
+}
+
+#[bench]
+fn downcast_failure(bencher: &mut Bencher) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyArray2::<i32>::zeros(py, (10, 10), false);
+
+        bencher.iter(|| {
+            black_box(any).downcast::<PyArray2<f64>>().unwrap_err();
+        });
+    });
+}
 struct Iter(Range<usize>);
 
 impl Iterator for Iter {

--- a/src/error.rs
+++ b/src/error.rs
@@ -162,3 +162,18 @@ impl fmt::Display for BorrowError {
 }
 
 impl_pyerr!(BorrowError);
+
+/// An internal type used to ignore certain error conditions
+///
+/// This is beneficial when those errors will never reach a public API anyway
+/// but dropping them will improve performance.
+pub(crate) struct IgnoreError;
+
+impl<E> From<E> for IgnoreError
+where
+    PyErr: From<E>,
+{
+    fn from(_err: E) -> Self {
+        Self
+    }
+}


### PR DESCRIPTION
This does give us the best of both worlds, i.e. avoid having to create a `PyErr` for downcast but still keeping a single implementation for the `extract` logic. I am just not sure whether this is wort the additional effort, i.e. the extra `ExtractionError` enum.