### PR TITLE
Fix use-after-free when calling to_npy_dims helper method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Unreleased
 
+- v0.17.1
+  - Fix use-after-free in `PyArray::resize`, `PyArray::reshape` and `PyArray::reshape_with_order`. ([#341](https://github.com/PyO3/rust-numpy/pull/341))
+
 - v0.17.0
   - Add dynamic borrow checking to safely construct references into the interior of NumPy arrays. ([#274](https://github.com/PyO3/rust-numpy/pull/274))
     - The deprecated iterator builders `NpySingleIterBuilder::{readonly,readwrite}` and `NpyMultiIterBuilder::add_{readonly,readwrite}` now take referencces to `PyReadonlyArray` and `PyReadwriteArray` instead of consuming them.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.17.0"
+version = "0.17.1"
 authors = [
     "The rust-numpy Project Developers",
     "PyO3 Project and Contributors <https://github.com/PyO3>"

--- a/src/array.rs
+++ b/src/array.rs
@@ -1379,7 +1379,8 @@ impl<T: Element, D> PyArray<T, D> {
         dims: ID,
         order: NPY_ORDER,
     ) -> PyResult<&'py PyArray<T, ID::Dim>> {
-        let mut dims = dims.into_dimension().to_npy_dims();
+        let dims = dims.into_dimension();
+        let mut dims = dims.to_npy_dims();
         let ptr = unsafe {
             PY_ARRAY_API.PyArray_Newshape(
                 self.py(),
@@ -1436,7 +1437,8 @@ impl<T: Element, D> PyArray<T, D> {
     /// [ndarray-resize]: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.resize.html
     /// [PyArray_Resize]: https://numpy.org/doc/stable/reference/c-api/array.html#c.PyArray_Resize
     pub unsafe fn resize<ID: IntoDimension>(&self, dims: ID) -> PyResult<()> {
-        let mut dims = dims.into_dimension().to_npy_dims();
+        let dims = dims.into_dimension();
+        let mut dims = dims.to_npy_dims();
         let res = PY_ARRAY_API.PyArray_Resize(
             self.py(),
             self.as_array_ptr(),

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -4,8 +4,8 @@ use std::mem::size_of;
 use half::f16;
 use ndarray::{array, s, Array1, Dim};
 use numpy::{
-    dtype, get_array_module, pyarray, PyArray, PyArray1, PyArray2, PyArrayDescr, PyArrayDyn,
-    ToPyArray,
+    dtype, get_array_module, npyffi::NPY_ORDER, pyarray, PyArray, PyArray1, PyArray2, PyArrayDescr,
+    PyArrayDyn, ToPyArray,
 };
 use pyo3::{
     py_run, pyclass, pymethods,
@@ -505,6 +505,23 @@ fn get_works() {
             assert_eq!(*array.uget_mut([0, 1, 0]), 3);
             assert_eq!(*array.uget_raw([0, 0, 1]), 2);
         }
+    });
+}
+
+#[test]
+fn reshape() {
+    Python::with_gil(|py| {
+        let array = PyArray::from_iter(py, 0..9)
+            .reshape_with_order([3, 3], NPY_ORDER::NPY_FORTRANORDER)
+            .unwrap();
+
+        assert_eq!(
+            array.readonly().as_array(),
+            array![[0, 3, 6], [1, 4, 7], [2, 5, 8]]
+        );
+        assert!(array.is_fortran_contiguous());
+
+        assert!(array.reshape([5]).is_err());
     });
 }
 


### PR DESCRIPTION
Closes #340 