### PR TITLE
Optional support for nalgebra types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Test
         run: |
             pip install numpy
-            cargo test
+            cargo test --all-features
         # Not on PyPy, because no embedding API
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
       - name: Test example
@@ -215,7 +215,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --lcov --output-path coverage.lcov
+        run: cargo llvm-cov --all-features --lcov --output-path coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - Unreleased
-  - Add conversions from datatypes provided by the [`nalgebra` crate](https://nalgebra.org/). ([#347](https://github.com/PyO3/rust-numpy/pull/347))
+  - Add conversions from and to datatypes provided by the [`nalgebra` crate](https://nalgebra.org/). ([#347](https://github.com/PyO3/rust-numpy/pull/347))
   - Drop our wrapper for NumPy iterators which were deprecated in v0.16.0 as ndarray's iteration facilities are almost always preferable. ([#324](https://github.com/PyO3/rust-numpy/pull/324))
 
 - v0.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - Add conversions from datatypes provided by the [`nalgebra` crate](https://nalgebra.org/). ([#347](https://github.com/PyO3/rust-numpy/pull/347))
   - Drop our wrapper for NumPy iterators which were deprecated in v0.16.0 as ndarray's iteration facilities are almost always preferable. ([#324](https://github.com/PyO3/rust-numpy/pull/324))
 
 - v0.17.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ pyo3 = { version = "0.17", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 pyo3 = { version = "0.17", default-features = false, features = ["auto-initialize"] }
+nalgebra = { version = "0.31", default-features = false, features = ["std"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ license = "BSD-2-Clause"
 ahash = "0.7"
 half = { version = "1.8", default-features = false, optional = true }
 libc = "0.2"
+nalgebra = { version = "0.31", default-features = false, optional = true }
 num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"

--- a/src/array.rs
+++ b/src/array.rs
@@ -1106,6 +1106,7 @@ where
     /// # Safety
     ///
     /// The existence of an exclusive reference to the internal data, e.g. `&mut [T]` or `ArrayViewMut`, implies undefined behavior.
+    #[doc(alias = "nalgebra")]
     pub unsafe fn try_as_matrix<R, C, RStride, CStride>(
         &self,
     ) -> Option<nalgebra::MatrixSlice<N, R, C, RStride, CStride>>
@@ -1127,6 +1128,7 @@ where
     /// # Safety
     ///
     /// The existence of another reference to the internal data, e.g. `&[T]` or `ArrayView`, implies undefined behavior.
+    #[doc(alias = "nalgebra")]
     pub unsafe fn try_as_matrix_mut<R, C, RStride, CStride>(
         &self,
     ) -> Option<nalgebra::MatrixSliceMut<N, R, C, RStride, CStride>>

--- a/src/array.rs
+++ b/src/array.rs
@@ -991,7 +991,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     ///
     /// # Safety
     ///
-    /// The existence of an exclusive reference to the internal data, e.g. `&mut [T]` or `ArrayViewMut`, implies undefined behavior.
+    /// Calling this method invalidates all exclusive references to the internal data, e.g. `&mut [T]` or `ArrayViewMut`.
     pub unsafe fn as_array(&self) -> ArrayView<'_, T, D> {
         self.as_view(|shape, ptr| ArrayView::from_shape_ptr(shape, ptr))
     }
@@ -1002,7 +1002,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     ///
     /// # Safety
     ///
-    /// The existence of another reference to the internal data, e.g. `&[T]` or `ArrayView`, implies undefined behavior.
+    /// Calling this method invalidates all other references to the internal data, e.g. `ArrayView` or `ArrayViewMut`.
     pub unsafe fn as_array_mut(&self) -> ArrayViewMut<'_, T, D> {
         self.as_view(|shape, ptr| ArrayViewMut::from_shape_ptr(shape, ptr))
     }
@@ -1105,7 +1105,7 @@ where
     ///
     /// # Safety
     ///
-    /// The existence of an exclusive reference to the internal data, e.g. `&mut [T]` or `ArrayViewMut`, implies undefined behavior.
+    /// Calling this method invalidates all exclusive references to the internal data, e.g. `ArrayViewMut` or `MatrixSliceMut`.
     #[doc(alias = "nalgebra")]
     pub unsafe fn try_as_matrix<R, C, RStride, CStride>(
         &self,
@@ -1127,7 +1127,7 @@ where
     ///
     /// # Safety
     ///
-    /// The existence of another reference to the internal data, e.g. `&[T]` or `ArrayView`, implies undefined behavior.
+    /// Calling this method invalidates all other references to the internal data, e.g. `ArrayView`, `MatrixSlice`, `ArrayViewMut` or `MatrixSliceMut`.
     #[doc(alias = "nalgebra")]
     pub unsafe fn try_as_matrix_mut<R, C, RStride, CStride>(
         &self,

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -481,6 +481,7 @@ where
     D: Dimension,
 {
     /// Try to convert this array into a [`nalgebra::MatrixSlice`] using the given shape and strides.
+    #[doc(alias = "nalgebra")]
     pub fn try_as_matrix<R, C, RStride, CStride>(
         &self,
     ) -> Option<nalgebra::MatrixSlice<N, R, C, RStride, CStride>>
@@ -504,6 +505,7 @@ where
     /// # Panics
     ///
     /// Panics if the array has negative strides.
+    #[doc(alias = "nalgebra")]
     pub fn as_matrix(&self) -> nalgebra::DMatrixSlice<N, nalgebra::Dynamic, nalgebra::Dynamic> {
         self.try_as_matrix().unwrap()
     }
@@ -519,6 +521,7 @@ where
     /// # Panics
     ///
     /// Panics if the array has negative strides.
+    #[doc(alias = "nalgebra")]
     pub fn as_matrix(&self) -> nalgebra::DMatrixSlice<N, nalgebra::Dynamic, nalgebra::Dynamic> {
         self.try_as_matrix().unwrap()
     }
@@ -679,6 +682,7 @@ where
     D: Dimension,
 {
     /// Try to convert this array into a [`nalgebra::MatrixSliceMut`] using the given shape and strides.
+    #[doc(alias = "nalgebra")]
     pub fn try_as_matrix_mut<R, C, RStride, CStride>(
         &self,
     ) -> Option<nalgebra::MatrixSliceMut<N, R, C, RStride, CStride>>
@@ -702,6 +706,7 @@ where
     /// # Panics
     ///
     /// Panics if the array has negative strides.
+    #[doc(alias = "nalgebra")]
     pub fn as_matrix_mut(
         &self,
     ) -> nalgebra::DMatrixSliceMut<N, nalgebra::Dynamic, nalgebra::Dynamic> {
@@ -719,6 +724,7 @@ where
     /// # Panics
     ///
     /// Panics if the array has negative strides.
+    #[doc(alias = "nalgebra")]
     pub fn as_matrix_mut(
         &self,
     ) -> nalgebra::DMatrixSliceMut<N, nalgebra::Dynamic, nalgebra::Dynamic> {

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -474,6 +474,56 @@ where
     }
 }
 
+#[cfg(feature = "nalgebra")]
+impl<'py, N, D> PyReadonlyArray<'py, N, D>
+where
+    N: nalgebra::Scalar + Element,
+    D: Dimension,
+{
+    /// Try to convert this array into a [`nalgebra::MatrixSlice`] using the given shape and strides.
+    pub fn try_as_matrix<R, C, RStride, CStride>(
+        &self,
+    ) -> Option<nalgebra::MatrixSlice<N, R, C, RStride, CStride>>
+    where
+        R: nalgebra::Dim,
+        C: nalgebra::Dim,
+        RStride: nalgebra::Dim,
+        CStride: nalgebra::Dim,
+    {
+        unsafe { self.array.try_as_matrix() }
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+impl<'py, N> PyReadonlyArray<'py, N, Ix1>
+where
+    N: nalgebra::Scalar + Element,
+{
+    /// Convert this one-dimensional array into a [`nalgebra::DMatrixSlice`] using dynamic strides.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the array has negative strides.
+    pub fn as_matrix(&self) -> nalgebra::DMatrixSlice<N, nalgebra::Dynamic, nalgebra::Dynamic> {
+        self.try_as_matrix().unwrap()
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+impl<'py, N> PyReadonlyArray<'py, N, Ix2>
+where
+    N: nalgebra::Scalar + Element,
+{
+    /// Convert this two-dimensional array into a [`nalgebra::DMatrixSlice`] using dynamic strides.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the array has negative strides.
+    pub fn as_matrix(&self) -> nalgebra::DMatrixSlice<N, nalgebra::Dynamic, nalgebra::Dynamic> {
+        self.try_as_matrix().unwrap()
+    }
+}
+
 impl<'a, T, D> Clone for PyReadonlyArray<'a, T, D>
 where
     T: Element,
@@ -619,6 +669,60 @@ where
         I: NpyIndex<Dim = D>,
     {
         unsafe { self.array.get_mut(index) }
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+impl<'py, N, D> PyReadwriteArray<'py, N, D>
+where
+    N: nalgebra::Scalar + Element,
+    D: Dimension,
+{
+    /// Try to convert this array into a [`nalgebra::MatrixSliceMut`] using the given shape and strides.
+    pub fn try_as_matrix_mut<R, C, RStride, CStride>(
+        &self,
+    ) -> Option<nalgebra::MatrixSliceMut<N, R, C, RStride, CStride>>
+    where
+        R: nalgebra::Dim,
+        C: nalgebra::Dim,
+        RStride: nalgebra::Dim,
+        CStride: nalgebra::Dim,
+    {
+        unsafe { self.array.try_as_matrix_mut() }
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+impl<'py, N> PyReadwriteArray<'py, N, Ix1>
+where
+    N: nalgebra::Scalar + Element,
+{
+    /// Convert this one-dimensional array into a [`nalgebra::DMatrixSliceMut`] using dynamic strides.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the array has negative strides.
+    pub fn as_matrix_mut(
+        &self,
+    ) -> nalgebra::DMatrixSliceMut<N, nalgebra::Dynamic, nalgebra::Dynamic> {
+        self.try_as_matrix_mut().unwrap()
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+impl<'py, N> PyReadwriteArray<'py, N, Ix2>
+where
+    N: nalgebra::Scalar + Element,
+{
+    /// Convert this two-dimensional array into a [`nalgebra::DMatrixSliceMut`] using dynamic strides.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the array has negative strides.
+    pub fn as_matrix_mut(
+        &self,
+    ) -> nalgebra::DMatrixSliceMut<N, nalgebra::Dynamic, nalgebra::Dynamic> {
+        self.try_as_matrix_mut().unwrap()
     }
 }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -194,6 +194,10 @@ where
     type Item = N;
     type Dim = crate::Ix2;
 
+    /// Note that the NumPy array always has Fortran memory layout
+    /// matching the [memory layout][memory-layout] used by [`nalgebra`].
+    ///
+    /// [memory-layout]: https://nalgebra.org/docs/faq/#what-is-the-memory-layout-of-matrices
     fn to_pyarray<'py>(&self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         unsafe {
             let array = PyArray::<N, _>::new(py, (self.nrows(), self.ncols()), true);

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -183,6 +183,30 @@ where
     }
 }
 
+#[cfg(feature = "nalgebra")]
+impl<N, R, C, S> ToPyArray for nalgebra::Matrix<N, R, C, S>
+where
+    N: nalgebra::Scalar + Element,
+    R: nalgebra::Dim,
+    C: nalgebra::Dim,
+    S: nalgebra::storage::Storage<N, R, C>,
+{
+    type Item = N;
+    type Dim = crate::Ix2;
+
+    fn to_pyarray<'py>(&self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
+        unsafe {
+            let array = PyArray::new(py, (self.nrows(), self.ncols()), false);
+            for r in 0..self.nrows() {
+                for c in 0..self.ncols() {
+                    *array.uget_mut((r, c)) = self.get_unchecked((r, c)).clone();
+                }
+            }
+            array
+        }
+    }
+}
+
 pub(crate) trait ArrayExt {
     fn npy_strides(&self) -> [npyffi::npy_intp; 32];
     fn order(&self) -> Option<c_int>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ mod sum_products;
 pub use ndarray;
 pub use pyo3;
 
+#[cfg(feature = "nalgebra")]
+pub use nalgebra;
+
 pub use crate::array::{
     get_array_module, PyArray, PyArray0, PyArray1, PyArray2, PyArray3, PyArray4, PyArray5,
     PyArray6, PyArrayDyn,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,12 @@
 //! Loading NumPy is done automatically and on demand. So if it is not installed, the functions
 //! provided by this crate will panic instead of returning a result.
 //!
+#![cfg_attr(
+    feature = "nalgebra",
+    doc = "Integration with [`nalgebra`] is rovided via an implementation of [`ToPyArray`] for [`nalgebra::Matrix`] to convert nalgebra matrices into NumPy arrays
+as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as_matrix_mut`] methods to treat NumPy array as nalgebra matrix slices.
+"
+)]
 //! # Example
 //!
 //! ```
@@ -26,7 +32,39 @@
 //!         py_array.readonly().as_array(),
 //!         array![[1i64, 2], [3, 4]]
 //!     );
-//! })
+//! });
+//! ```
+//!
+#![cfg_attr(feature = "nalgebra", doc = "```")]
+#![cfg_attr(not(feature = "nalgebra"), doc = "```rust,ignore")]
+//! use numpy::pyo3::Python;
+//! use numpy::nalgebra::Matrix3;
+//! use numpy::{pyarray, ToPyArray};
+//!
+//! Python::with_gil(|py| {
+//!     let py_array = pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+//!
+//!     let py_array_square;
+//!
+//!     {
+//!         let py_array = py_array.readwrite();
+//!         let mut na_matrix = py_array.as_matrix_mut();
+//!
+//!         na_matrix.add_scalar_mut(1);
+//!
+//!         py_array_square = na_matrix.pow(2).to_pyarray(py);
+//!     }
+//!
+//!     assert_eq!(
+//!         py_array.readonly().as_matrix(),
+//!         Matrix3::new(1, 2, 3, 4, 5, 6, 7, 8, 9)
+//!     );
+//!
+//!     assert_eq!(
+//!         py_array_square.readonly().as_matrix(),
+//!         Matrix3::new(30, 36, 42, 66, 81, 96, 102, 126, 150)
+//!     );
+//! });
 //! ```
 //!
 //! [c-api]: https://numpy.org/doc/stable/reference/c-api

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -342,3 +342,69 @@ fn resize_using_exclusive_borrow() {
         assert_eq!(array.as_slice_mut().unwrap(), &[0.0; 5]);
     });
 }
+
+#[cfg(feature = "nalgebra")]
+#[test]
+fn matrix_from_numpy() {
+    Python::with_gil(|py| {
+        let array = numpy::pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+
+        {
+            let array = array.readonly();
+
+            let matrix = array.as_matrix();
+            assert_eq!(matrix, nalgebra::Matrix3::new(0, 1, 2, 3, 4, 5, 6, 7, 8));
+
+            let matrix: nalgebra::MatrixSlice<
+                i32,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<1>,
+            > = array.try_as_matrix().unwrap();
+            assert_eq!(matrix, nalgebra::Matrix3::new(0, 1, 2, 3, 4, 5, 6, 7, 8));
+        }
+
+        {
+            let array = array.readwrite();
+
+            let matrix = array.as_matrix_mut();
+            assert_eq!(matrix, nalgebra::Matrix3::new(0, 1, 2, 3, 4, 5, 6, 7, 8));
+
+            let matrix: nalgebra::MatrixSliceMut<
+                i32,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<1>,
+            > = array.try_as_matrix_mut().unwrap();
+            assert_eq!(matrix, nalgebra::Matrix3::new(0, 1, 2, 3, 4, 5, 6, 7, 8));
+        }
+    });
+
+    Python::with_gil(|py| {
+        let array = numpy::pyarray![py, 0, 1, 2];
+
+        {
+            let array = array.readonly();
+
+            let matrix = array.as_matrix();
+            assert_eq!(matrix, nalgebra::Matrix3x1::new(0, 1, 2));
+
+            let matrix: nalgebra::MatrixSlice<i32, nalgebra::Const<3>, nalgebra::Const<1>> =
+                array.try_as_matrix().unwrap();
+            assert_eq!(matrix, nalgebra::Matrix3x1::new(0, 1, 2));
+        }
+
+        {
+            let array = array.readwrite();
+
+            let matrix = array.as_matrix_mut();
+            assert_eq!(matrix, nalgebra::Matrix3x1::new(0, 1, 2));
+
+            let matrix: nalgebra::MatrixSliceMut<i32, nalgebra::Const<3>, nalgebra::Const<1>> =
+                array.try_as_matrix_mut().unwrap();
+            assert_eq!(matrix, nalgebra::Matrix3x1::new(0, 1, 2));
+        }
+    });
+}

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -407,4 +407,76 @@ fn matrix_from_numpy() {
             assert_eq!(matrix, nalgebra::Matrix3x1::new(0, 1, 2));
         }
     });
+
+    Python::with_gil(|py| {
+        let array = PyArray::<i32, _>::zeros(py, (2, 2, 2), false);
+        let array = array.readonly();
+
+        let matrix: Option<nalgebra::DMatrixSlice<i32, nalgebra::Dynamic, nalgebra::Dynamic>> =
+            array.try_as_matrix();
+        assert!(matrix.is_none());
+    });
+
+    Python::with_gil(|py| {
+        let array = numpy::pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+        let array: &PyArray2<i32> = py
+            .eval("a[::-1]", Some([("a", array)].into_py_dict(py)), None)
+            .unwrap()
+            .downcast()
+            .unwrap();
+        let array = array.readonly();
+
+        let matrix: Option<nalgebra::DMatrixSlice<i32, nalgebra::Dynamic, nalgebra::Dynamic>> =
+            array.try_as_matrix();
+        assert!(matrix.is_none());
+    });
+
+    Python::with_gil(|py| {
+        let array = numpy::pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+        let array = array.readonly();
+
+        let matrix: Option<
+            nalgebra::MatrixSlice<
+                i32,
+                nalgebra::Const<2>,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<1>,
+            >,
+        > = array.try_as_matrix();
+        assert!(matrix.is_none());
+
+        let matrix: Option<
+            nalgebra::MatrixSlice<
+                i32,
+                nalgebra::Const<3>,
+                nalgebra::Const<2>,
+                nalgebra::Const<3>,
+                nalgebra::Const<1>,
+            >,
+        > = array.try_as_matrix();
+        assert!(matrix.is_none());
+
+        let matrix: Option<
+            nalgebra::MatrixSlice<
+                i32,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<2>,
+                nalgebra::Const<1>,
+            >,
+        > = array.try_as_matrix();
+        assert!(matrix.is_none());
+
+        let matrix: Option<
+            nalgebra::MatrixSlice<
+                i32,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<3>,
+                nalgebra::Const<2>,
+            >,
+        > = array.try_as_matrix();
+        assert!(matrix.is_none());
+    });
 }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -303,6 +303,7 @@ fn slice_container_type_confusion() {
 #[test]
 fn matrix_to_numpy() {
     let matrix = nalgebra::Matrix3::<i32>::new(0, 1, 2, 3, 4, 5, 6, 7, 8);
+    assert!(nalgebra::RawStorage::is_contiguous(&matrix.data));
 
     Python::with_gil(|py| {
         let array = matrix.to_pyarray(py);
@@ -311,5 +312,14 @@ fn matrix_to_numpy() {
             array.readonly().as_array(),
             array![[0, 1, 2], [3, 4, 5], [6, 7, 8]],
         );
+    });
+
+    let matrix = matrix.row(0);
+    assert!(!nalgebra::RawStorage::is_contiguous(&matrix.data));
+
+    Python::with_gil(|py| {
+        let array = matrix.to_pyarray(py);
+
+        assert_eq!(array.readonly().as_array(), array![[0, 1, 2]]);
     });
 }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -322,4 +322,20 @@ fn matrix_to_numpy() {
 
         assert_eq!(array.readonly().as_array(), array![[0, 1, 2]]);
     });
+
+    let vector = nalgebra::Vector4::<i32>::new(-4, 1, 2, 3);
+
+    Python::with_gil(|py| {
+        let array = vector.to_pyarray(py);
+
+        assert_eq!(array.readonly().as_array(), array![[-4], [1], [2], [3]]);
+    });
+
+    let vector = nalgebra::RowVector2::<i32>::new(23, 42);
+
+    Python::with_gil(|py| {
+        let array = vector.to_pyarray(py);
+
+        assert_eq!(array.readonly().as_array(), array![[23, 42]]);
+    });
 }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -298,3 +298,18 @@ fn slice_container_type_confusion() {
         let _py_arr = vec![1, 2, 3].into_pyarray(py);
     });
 }
+
+#[cfg(feature = "nalgebra")]
+#[test]
+fn matrix_to_numpy() {
+    let matrix = nalgebra::Matrix3::<i32>::new(0, 1, 2, 3, 4, 5, 6, 7, 8);
+
+    Python::with_gil(|py| {
+        let array = matrix.to_pyarray(py);
+
+        assert_eq!(
+            array.readonly().as_array(),
+            array![[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+        );
+    });
+}


### PR DESCRIPTION
This is loosely based on https://github.com/qsib-cbie/nalgebra-numpy (which is based on https://github.com/fusion-engineering/nalgebra-numpy targetting an older version of `pyo3`) but I tried to achieve a deeper integration into our existing types and optimized the `ToPyArray` implementation to copy contiguous data using `ptr::copy_nonoverlapping`.

Closes #263