### PR TITLE
Bump half dependency to the current stable version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "BSD-2-Clause"
 
 [dependencies]
 ahash = "0.7"
-half = { version = "1.8", default-features = false, optional = true }
+half = { version = "2.0", default-features = false, optional = true }
 libc = "0.2"
 nalgebra = { version = "0.31", default-features = false, optional = true }
 num-complex = ">= 0.2, < 0.5"

--- a/x.py
+++ b/x.py
@@ -68,9 +68,6 @@ def check(args):
             "--",
             "--deny",
             "warnings",
-            # https://github.com/PyO3/pyo3/issues/2555
-            "--allow",
-            "clippy::borrow-deref-ref",
         )
 
 


### PR DESCRIPTION
`half` is part of our API and hence this is a breaking change. This also increases MSRV to 1.58 if `half` is enabled. (It was already 1.51 if `half` is enabled before, i.e. not compatible with our MSRV of 1.48.)