### PR TITLE
RFC: Replace AHash (DoS-resistant) by FxHash (simpler dependency)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["python", "numpy", "ffi", "pyo3"]
 license = "BSD-2-Clause"
 
 [dependencies]
-ahash = "0.7"
 half = { version = "2.0", default-features = false, optional = true }
 libc = "0.2"
 nalgebra = { version = "0.31", default-features = false, optional = true }
@@ -24,6 +23,7 @@ num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
 pyo3 = { version = "0.17", default-features = false, features = ["macros"] }
+rustc-hash = "1.1"
 
 [dev-dependencies]
 pyo3 = { version = "0.17", default-features = false, features = ["auto-initialize"] }

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -256,7 +256,7 @@ impl BorrowFlags {
     fn acquire(&self, _py: Python, address: *mut u8, key: BorrowKey) -> Result<(), BorrowError> {
         // SAFETY: Having `_py` implies holding the GIL and
         // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { BORROW_FLAGS.get() };
+        let borrow_flags = unsafe { self.get() };
 
         match borrow_flags.entry(address) {
             Entry::Occupied(entry) => {
@@ -299,7 +299,7 @@ impl BorrowFlags {
     fn release(&self, _py: Python, address: *mut u8, key: BorrowKey) {
         // SAFETY: Having `_py` implies holding the GIL and
         // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { BORROW_FLAGS.get() };
+        let borrow_flags = unsafe { self.get() };
 
         let same_base_arrays = borrow_flags.get_mut(&address).unwrap();
 
@@ -324,7 +324,7 @@ impl BorrowFlags {
     ) -> Result<(), BorrowError> {
         // SAFETY: Having `_py` implies holding the GIL and
         // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { BORROW_FLAGS.get() };
+        let borrow_flags = unsafe { self.get() };
 
         match borrow_flags.entry(address) {
             Entry::Occupied(entry) => {
@@ -361,7 +361,7 @@ impl BorrowFlags {
     fn release_mut(&self, _py: Python, address: *mut u8, key: BorrowKey) {
         // SAFETY: Having `_py` implies holding the GIL and
         // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { BORROW_FLAGS.get() };
+        let borrow_flags = unsafe { self.get() };
 
         let same_base_arrays = borrow_flags.get_mut(&address).unwrap();
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -63,8 +63,8 @@ use std::fmt;
 use std::hash::Hash;
 use std::marker::PhantomData;
 
-use ahash::AHashMap;
 use pyo3::{Py, Python};
+use rustc_hash::FxHashMap;
 
 use crate::dtype::{Element, PyArrayDescr};
 use crate::npyffi::{PyArray_DatetimeDTypeMetaData, NPY_DATETIMEUNIT, NPY_TYPES};
@@ -206,7 +206,7 @@ impl<U: Unit> fmt::Debug for Timedelta<U> {
 
 struct TypeDescriptors {
     npy_type: NPY_TYPES,
-    dtypes: UnsafeCell<Option<AHashMap<NPY_DATETIMEUNIT, Py<PyArrayDescr>>>>,
+    dtypes: UnsafeCell<Option<FxHashMap<NPY_DATETIMEUNIT, Py<PyArrayDescr>>>>,
 }
 
 unsafe impl Sync for TypeDescriptors {}
@@ -221,8 +221,8 @@ impl TypeDescriptors {
     }
 
     #[allow(clippy::mut_from_ref)]
-    unsafe fn get(&self) -> &mut AHashMap<NPY_DATETIMEUNIT, Py<PyArrayDescr>> {
-        (*self.dtypes.get()).get_or_insert_with(AHashMap::new)
+    unsafe fn get(&self) -> &mut FxHashMap<NPY_DATETIMEUNIT, Py<PyArrayDescr>> {
+        (*self.dtypes.get()).get_or_insert_with(Default::default)
     }
 
     #[allow(clippy::wrong_self_convention)]


### PR DESCRIPTION
This is motivated by the issue unearthed in #352. (The first commit fixes a luckily inconsequential mistake that slipped through review.)

In the `datetime` module, we hash a set of keys known at compile time and hence are not subject to DoS issues.
    
In the `borrow` module, the keys include pointer addresses which means that even if a program exposes its usage of NumPy arrays to remote user control, a DoS attack would also need detailed control over the placement of memory allocations in which case outright memory exhaustion seems to be a simpler avenue of attack.
