### PR TITLE
RFC: Perform borrow checking through a capsule-based API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Unreleased
   - Add conversions from and to datatypes provided by the [`nalgebra` crate](https://nalgebra.org/). ([#347](https://github.com/PyO3/rust-numpy/pull/347))
   - Drop our wrapper for NumPy iterators which were deprecated in v0.16.0 as ndarray's iteration facilities are almost always preferable. ([#324](https://github.com/PyO3/rust-numpy/pull/324))
+  - Dynamic borrow checking now uses a capsule-based API and therefore works across multiple extensions using PyO3 and potentially other bindings or languages. ([#361](https://github.com/PyO3/rust-numpy/pull/361))
 
 - v0.17.2
   - Fix unsound aliasing into `Box<[T]>` when converting them into NumPy arrays. ([#351](https://github.com/PyO3/rust-numpy/pull/351))

--- a/src/borrow/mod.rs
+++ b/src/borrow/mod.rs
@@ -164,22 +164,19 @@ mod shared;
 
 use std::any::type_name;
 use std::fmt;
-use std::mem::size_of;
 use std::ops::Deref;
 
 use ndarray::{
     ArrayView, ArrayViewMut, Dimension, IntoDimension, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn,
 };
-use num_integer::gcd;
-use pyo3::{FromPyObject, PyAny, PyResult, Python};
+use pyo3::{FromPyObject, PyAny, PyResult};
 
 use crate::array::PyArray;
 use crate::convert::NpyIndex;
 use crate::dtype::Element;
 use crate::error::{BorrowError, NotContiguousError};
-use crate::npyffi::{self, PyArrayObject, NPY_ARRAY_WRITEABLE};
 
-use shared::{acquire, acquire_mut, release, release_mut, BorrowKey};
+use shared::{acquire, acquire_mut, release, release_mut};
 
 /// Read-only borrow of an array.
 ///
@@ -194,8 +191,6 @@ where
     D: Dimension,
 {
     array: &'py PyArray<T, D>,
-    address: *mut u8,
-    key: BorrowKey,
 }
 
 /// Read-only borrow of a one-dimensional array.
@@ -244,16 +239,9 @@ where
     D: Dimension,
 {
     pub(crate) fn try_new(array: &'py PyArray<T, D>) -> Result<Self, BorrowError> {
-        let address = base_address(array);
-        let key = borrow_key(array);
+        acquire(array.py(), array.as_array_ptr())?;
 
-        acquire(array.py(), address, key)?;
-
-        Ok(Self {
-            array,
-            address,
-            key,
-        })
+        Ok(Self { array })
     }
 
     /// Provides an immutable array view of the interior of the NumPy array.
@@ -339,13 +327,9 @@ where
     D: Dimension,
 {
     fn clone(&self) -> Self {
-        acquire(self.array.py(), self.address, self.key).unwrap();
+        acquire(self.array.py(), self.array.as_array_ptr()).unwrap();
 
-        Self {
-            array: self.array,
-            address: self.address,
-            key: self.key,
-        }
+        Self { array: self.array }
     }
 }
 
@@ -355,7 +339,7 @@ where
     D: Dimension,
 {
     fn drop(&mut self) {
-        release(self.array.py(), self.address, self.key);
+        release(self.array.py(), self.array.as_array_ptr());
     }
 }
 
@@ -388,8 +372,6 @@ where
     D: Dimension,
 {
     array: &'py PyArray<T, D>,
-    address: *mut u8,
-    key: BorrowKey,
 }
 
 /// Read-write borrow of a one-dimensional array.
@@ -439,20 +421,9 @@ where
     D: Dimension,
 {
     pub(crate) fn try_new(array: &'py PyArray<T, D>) -> Result<Self, BorrowError> {
-        if !array.check_flags(NPY_ARRAY_WRITEABLE) {
-            return Err(BorrowError::NotWriteable);
-        }
+        acquire_mut(array.py(), array.as_array_ptr())?;
 
-        let address = base_address(array);
-        let key = borrow_key(array);
-
-        acquire_mut(array.py(), address, key)?;
-
-        Ok(Self {
-            array,
-            address,
-            key,
-        })
+        Ok(Self { array })
     }
 
     /// Provides a mutable array view of the interior of the NumPy array.
@@ -579,7 +550,7 @@ where
     D: Dimension,
 {
     fn drop(&mut self) {
-        release_mut(self.array.py(), self.address, self.key);
+        release_mut(self.array.py(), self.array.as_array_ptr());
     }
 }
 
@@ -599,382 +570,13 @@ where
     }
 }
 
-fn base_address<T, D>(array: &PyArray<T, D>) -> *mut u8 {
-    fn inner(py: Python, mut array: *mut PyArrayObject) -> *mut u8 {
-        loop {
-            let base = unsafe { (*array).base };
-
-            if base.is_null() {
-                return array as *mut u8;
-            } else if unsafe { npyffi::PyArray_Check(py, base) } != 0 {
-                array = base as *mut PyArrayObject;
-            } else {
-                return base as *mut u8;
-            }
-        }
-    }
-
-    inner(array.py(), array.as_array_ptr())
-}
-
-fn borrow_key<T, D>(array: &PyArray<T, D>) -> BorrowKey
-where
-    T: Element,
-    D: Dimension,
-{
-    let range = data_range(array);
-
-    let data_ptr = array.data() as *mut u8;
-    let gcd_strides = gcd_strides(array.strides());
-
-    BorrowKey {
-        range,
-        data_ptr,
-        gcd_strides,
-    }
-}
-
-fn data_range<T, D>(array: &PyArray<T, D>) -> (*mut u8, *mut u8)
-where
-    T: Element,
-    D: Dimension,
-{
-    fn inner(
-        shape: &[usize],
-        strides: &[isize],
-        itemsize: isize,
-        data: *mut u8,
-    ) -> (*mut u8, *mut u8) {
-        let mut start = 0;
-        let mut end = 0;
-
-        if shape.iter().all(|dim| *dim != 0) {
-            for (&dim, &stride) in shape.iter().zip(strides) {
-                let offset = (dim - 1) as isize * stride;
-
-                if offset >= 0 {
-                    end += offset;
-                } else {
-                    start += offset;
-                }
-            }
-
-            end += itemsize;
-        }
-
-        let start = unsafe { data.offset(start) };
-        let end = unsafe { data.offset(end) };
-
-        (start, end)
-    }
-
-    inner(
-        array.shape(),
-        array.strides(),
-        size_of::<T>() as isize,
-        array.data() as *mut u8,
-    )
-}
-
-fn gcd_strides(strides: &[isize]) -> isize {
-    reduce(strides.iter().copied(), gcd).unwrap_or(1)
-}
-
-// FIXME(adamreichold): Use `Iterator::reduce` from std when our MSRV reaches 1.51.
-fn reduce<I, F>(mut iter: I, f: F) -> Option<I::Item>
-where
-    I: Iterator,
-    F: FnMut(I::Item, I::Item) -> I::Item,
-{
-    let first = iter.next()?;
-    Some(iter.fold(first, f))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use ndarray::Array;
     use pyo3::{types::IntoPyDict, Python};
 
-    use crate::array::{PyArray1, PyArray2, PyArray3};
-    use crate::convert::IntoPyArray;
-
-    #[test]
-    fn without_base_object() {
-        Python::with_gil(|py| {
-            let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
-
-            let base = unsafe { (*array.as_array_ptr()).base };
-            assert!(base.is_null());
-
-            let base_address = base_address(array);
-            assert_eq!(base_address, array as *const _ as *mut u8);
-
-            let data_range = data_range(array);
-            assert_eq!(data_range.0, array.data() as *mut u8);
-            assert_eq!(data_range.1, unsafe { array.data().add(6) } as *mut u8);
-        });
-    }
-
-    #[test]
-    fn with_base_object() {
-        Python::with_gil(|py| {
-            let array = Array::<f64, _>::zeros((1, 2, 3)).into_pyarray(py);
-
-            let base = unsafe { (*array.as_array_ptr()).base };
-            assert!(!base.is_null());
-
-            let base_address = base_address(array);
-            assert_ne!(base_address, array as *const _ as *mut u8);
-            assert_eq!(base_address, base as *mut u8);
-
-            let data_range = data_range(array);
-            assert_eq!(data_range.0, array.data() as *mut u8);
-            assert_eq!(data_range.1, unsafe { array.data().add(6) } as *mut u8);
-        });
-    }
-
-    #[test]
-    fn view_without_base_object() {
-        Python::with_gil(|py| {
-            let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
-
-            let locals = [("array", array)].into_py_dict(py);
-            let view = py
-                .eval("array[:,:,0]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-            assert_ne!(view as *const _ as *mut u8, array as *const _ as *mut u8);
-
-            let base = unsafe { (*view.as_array_ptr()).base };
-            assert_eq!(base as *mut u8, array as *const _ as *mut u8);
-
-            let base_address = base_address(view);
-            assert_ne!(base_address, view as *const _ as *mut u8);
-            assert_eq!(base_address, base as *mut u8);
-
-            let data_range = data_range(view);
-            assert_eq!(data_range.0, array.data() as *mut u8);
-            assert_eq!(data_range.1, unsafe { array.data().add(4) } as *mut u8);
-        });
-    }
-
-    #[test]
-    fn view_with_base_object() {
-        Python::with_gil(|py| {
-            let array = Array::<f64, _>::zeros((1, 2, 3)).into_pyarray(py);
-
-            let locals = [("array", array)].into_py_dict(py);
-            let view = py
-                .eval("array[:,:,0]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-            assert_ne!(view as *const _ as *mut u8, array as *const _ as *mut u8);
-
-            let base = unsafe { (*view.as_array_ptr()).base };
-            assert_eq!(base as *mut u8, array as *const _ as *mut u8);
-
-            let base = unsafe { (*array.as_array_ptr()).base };
-            assert!(!base.is_null());
-
-            let base_address = base_address(view);
-            assert_ne!(base_address, view as *const _ as *mut u8);
-            assert_ne!(base_address, array as *const _ as *mut u8);
-            assert_eq!(base_address, base as *mut u8);
-
-            let data_range = data_range(view);
-            assert_eq!(data_range.0, array.data() as *mut u8);
-            assert_eq!(data_range.1, unsafe { array.data().add(4) } as *mut u8);
-        });
-    }
-
-    #[test]
-    fn view_of_view_without_base_object() {
-        Python::with_gil(|py| {
-            let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
-
-            let locals = [("array", array)].into_py_dict(py);
-            let view1 = py
-                .eval("array[:,:,0]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-            assert_ne!(view1 as *const _ as *mut u8, array as *const _ as *mut u8);
-
-            let locals = [("view1", view1)].into_py_dict(py);
-            let view2 = py
-                .eval("view1[:,0]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray1<f64>>()
-                .unwrap();
-            assert_ne!(view2 as *const _ as *mut u8, array as *const _ as *mut u8);
-            assert_ne!(view2 as *const _ as *mut u8, view1 as *const _ as *mut u8);
-
-            let base = unsafe { (*view2.as_array_ptr()).base };
-            assert_eq!(base as *mut u8, array as *const _ as *mut u8);
-
-            let base = unsafe { (*view1.as_array_ptr()).base };
-            assert_eq!(base as *mut u8, array as *const _ as *mut u8);
-
-            let base_address = base_address(view2);
-            assert_ne!(base_address, view2 as *const _ as *mut u8);
-            assert_ne!(base_address, view1 as *const _ as *mut u8);
-            assert_eq!(base_address, base as *mut u8);
-
-            let data_range = data_range(view2);
-            assert_eq!(data_range.0, array.data() as *mut u8);
-            assert_eq!(data_range.1, unsafe { array.data().add(1) } as *mut u8);
-        });
-    }
-
-    #[test]
-    fn view_of_view_with_base_object() {
-        Python::with_gil(|py| {
-            let array = Array::<f64, _>::zeros((1, 2, 3)).into_pyarray(py);
-
-            let locals = [("array", array)].into_py_dict(py);
-            let view1 = py
-                .eval("array[:,:,0]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-            assert_ne!(view1 as *const _ as *mut u8, array as *const _ as *mut u8);
-
-            let locals = [("view1", view1)].into_py_dict(py);
-            let view2 = py
-                .eval("view1[:,0]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray1<f64>>()
-                .unwrap();
-            assert_ne!(view2 as *const _ as *mut u8, array as *const _ as *mut u8);
-            assert_ne!(view2 as *const _ as *mut u8, view1 as *const _ as *mut u8);
-
-            let base = unsafe { (*view2.as_array_ptr()).base };
-            assert_eq!(base as *mut u8, array as *const _ as *mut u8);
-
-            let base = unsafe { (*view1.as_array_ptr()).base };
-            assert_eq!(base as *mut u8, array as *const _ as *mut u8);
-
-            let base = unsafe { (*array.as_array_ptr()).base };
-            assert!(!base.is_null());
-
-            let base_address = base_address(view2);
-            assert_ne!(base_address, view2 as *const _ as *mut u8);
-            assert_ne!(base_address, view1 as *const _ as *mut u8);
-            assert_ne!(base_address, array as *const _ as *mut u8);
-            assert_eq!(base_address, base as *mut u8);
-
-            let data_range = data_range(view2);
-            assert_eq!(data_range.0, array.data() as *mut u8);
-            assert_eq!(data_range.1, unsafe { array.data().add(1) } as *mut u8);
-        });
-    }
-
-    #[test]
-    fn view_with_negative_strides() {
-        Python::with_gil(|py| {
-            let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
-
-            let locals = [("array", array)].into_py_dict(py);
-            let view = py
-                .eval("array[::-1,:,::-1]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray3<f64>>()
-                .unwrap();
-            assert_ne!(view as *const _ as *mut u8, array as *const _ as *mut u8);
-
-            let base = unsafe { (*view.as_array_ptr()).base };
-            assert_eq!(base as *mut u8, array as *const _ as *mut u8);
-
-            let base_address = base_address(view);
-            assert_ne!(base_address, view as *const _ as *mut u8);
-            assert_eq!(base_address, base as *mut u8);
-
-            let data_range = data_range(view);
-            assert_eq!(view.data(), unsafe { array.data().offset(2) });
-            assert_eq!(data_range.0, unsafe { view.data().offset(-2) } as *mut u8);
-            assert_eq!(data_range.1, unsafe { view.data().offset(4) } as *mut u8);
-        });
-    }
-
-    #[test]
-    fn array_with_zero_dimensions() {
-        Python::with_gil(|py| {
-            let array = PyArray::<f64, _>::zeros(py, (1, 0, 3), false);
-
-            let base = unsafe { (*array.as_array_ptr()).base };
-            assert!(base.is_null());
-
-            let base_address = base_address(array);
-            assert_eq!(base_address, array as *const _ as *mut u8);
-
-            let data_range = data_range(array);
-            assert_eq!(data_range.0, array.data() as *mut u8);
-            assert_eq!(data_range.1, array.data() as *mut u8);
-        });
-    }
-
-    #[test]
-    fn view_with_non_dividing_strides() {
-        Python::with_gil(|py| {
-            let array = PyArray::<f64, _>::zeros(py, (10, 10), false);
-            let locals = [("array", array)].into_py_dict(py);
-
-            let view1 = py
-                .eval("array[:,::3]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-
-            let key1 = borrow_key(view1);
-
-            assert_eq!(view1.strides(), &[80, 24]);
-            assert_eq!(key1.gcd_strides, 8);
-
-            let view2 = py
-                .eval("array[:,1::3]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-
-            let key2 = borrow_key(view2);
-
-            assert_eq!(view2.strides(), &[80, 24]);
-            assert_eq!(key2.gcd_strides, 8);
-
-            let view3 = py
-                .eval("array[:,::2]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-
-            let key3 = borrow_key(view3);
-
-            assert_eq!(view3.strides(), &[80, 16]);
-            assert_eq!(key3.gcd_strides, 16);
-
-            let view4 = py
-                .eval("array[:,1::2]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray2<f64>>()
-                .unwrap();
-
-            let key4 = borrow_key(view4);
-
-            assert_eq!(view4.strides(), &[80, 16]);
-            assert_eq!(key4.gcd_strides, 16);
-
-            assert!(!key3.conflicts(&key4));
-            assert!(key1.conflicts(&key3));
-            assert!(key2.conflicts(&key4));
-
-            // This is a false conflict where all aliasing indices like (0,7) and (2,0) are out of bounds.
-            assert!(key1.conflicts(&key2));
-        });
-    }
+    use crate::array::PyArray1;
 
     #[test]
     fn test_debug_formatting() {

--- a/src/borrow/mod.rs
+++ b/src/borrow/mod.rs
@@ -179,7 +179,7 @@ use crate::dtype::Element;
 use crate::error::{BorrowError, NotContiguousError};
 use crate::npyffi::{self, PyArrayObject, NPY_ARRAY_WRITEABLE};
 
-use shared::{BorrowKey, BORROW_FLAGS};
+use shared::{acquire, acquire_mut, release, release_mut, BorrowKey};
 
 /// Read-only borrow of an array.
 ///
@@ -247,7 +247,7 @@ where
         let address = base_address(array);
         let key = borrow_key(array);
 
-        BORROW_FLAGS.acquire(array.py(), address, key)?;
+        acquire(array.py(), address, key)?;
 
         Ok(Self {
             array,
@@ -339,9 +339,7 @@ where
     D: Dimension,
 {
     fn clone(&self) -> Self {
-        BORROW_FLAGS
-            .acquire(self.array.py(), self.address, self.key)
-            .unwrap();
+        acquire(self.array.py(), self.address, self.key).unwrap();
 
         Self {
             array: self.array,
@@ -357,7 +355,7 @@ where
     D: Dimension,
 {
     fn drop(&mut self) {
-        BORROW_FLAGS.release(self.array.py(), self.address, self.key);
+        release(self.array.py(), self.address, self.key);
     }
 }
 
@@ -448,7 +446,7 @@ where
         let address = base_address(array);
         let key = borrow_key(array);
 
-        BORROW_FLAGS.acquire_mut(array.py(), address, key)?;
+        acquire_mut(array.py(), address, key)?;
 
         Ok(Self {
             array,
@@ -581,7 +579,7 @@ where
     D: Dimension,
 {
     fn drop(&mut self) {
-        BORROW_FLAGS.release_mut(self.array.py(), self.address, self.key);
+        release_mut(self.array.py(), self.address, self.key);
     }
 }
 

--- a/src/borrow/mod.rs
+++ b/src/borrow/mod.rs
@@ -160,9 +160,9 @@
 //!
 //! [base]: https://numpy.org/doc/stable/reference/c-api/types-and-structures.html#c.NPY_AO.base
 
+mod shared;
+
 use std::any::type_name;
-use std::cell::UnsafeCell;
-use std::collections::hash_map::Entry;
 use std::fmt;
 use std::mem::size_of;
 use std::ops::Deref;
@@ -172,210 +172,14 @@ use ndarray::{
 };
 use num_integer::gcd;
 use pyo3::{FromPyObject, PyAny, PyResult, Python};
-use rustc_hash::FxHashMap;
 
 use crate::array::PyArray;
-use crate::cold;
 use crate::convert::NpyIndex;
 use crate::dtype::Element;
 use crate::error::{BorrowError, NotContiguousError};
 use crate::npyffi::{self, PyArrayObject, NPY_ARRAY_WRITEABLE};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct BorrowKey {
-    /// exclusive range of lowest and highest address covered by array
-    range: (*mut u8, *mut u8),
-    /// the data address on which address computations are based
-    data_ptr: *mut u8,
-    /// the greatest common divisor of the strides of the array
-    gcd_strides: isize,
-}
-
-impl BorrowKey {
-    fn from_array<T, D>(array: &PyArray<T, D>) -> Self
-    where
-        T: Element,
-        D: Dimension,
-    {
-        let range = data_range(array);
-
-        let data_ptr = array.data() as *mut u8;
-        let gcd_strides = gcd_strides(array.strides());
-
-        Self {
-            range,
-            data_ptr,
-            gcd_strides,
-        }
-    }
-
-    fn conflicts(&self, other: &Self) -> bool {
-        debug_assert!(self.range.0 <= self.range.1);
-        debug_assert!(other.range.0 <= other.range.1);
-
-        if other.range.0 >= self.range.1 || self.range.0 >= other.range.1 {
-            return false;
-        }
-
-        // The Diophantine equation which describes whether any integers can combine the data pointers and strides of the two arrays s.t.
-        // they yield the same element has a solution if and only if the GCD of all strides divides the difference of the data pointers.
-        //
-        // That solution could be out of bounds which mean that this is still an over-approximation.
-        // It appears sufficient to handle typical cases like the color channels of an image,
-        // but fails when slicing an array with a step size that does not divide the dimension along that axis.
-        //
-        // https://users.rust-lang.org/t/math-for-borrow-checking-numpy-arrays/73303
-        let ptr_diff = unsafe { self.data_ptr.offset_from(other.data_ptr).abs() };
-        let gcd_strides = gcd(self.gcd_strides, other.gcd_strides);
-
-        if ptr_diff % gcd_strides != 0 {
-            return false;
-        }
-
-        // By default, a conflict is assumed as it is the safe choice without actually solving the aliasing equation.
-        true
-    }
-}
-
-type BorrowFlagsInner = FxHashMap<*mut u8, FxHashMap<BorrowKey, isize>>;
-
-struct BorrowFlags(UnsafeCell<Option<BorrowFlagsInner>>);
-
-unsafe impl Sync for BorrowFlags {}
-
-impl BorrowFlags {
-    const fn new() -> Self {
-        Self(UnsafeCell::new(None))
-    }
-
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn get(&self) -> &mut BorrowFlagsInner {
-        (*self.0.get()).get_or_insert_with(Default::default)
-    }
-
-    fn acquire(&self, _py: Python, address: *mut u8, key: BorrowKey) -> Result<(), BorrowError> {
-        // SAFETY: Having `_py` implies holding the GIL and
-        // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { self.get() };
-
-        match borrow_flags.entry(address) {
-            Entry::Occupied(entry) => {
-                let same_base_arrays = entry.into_mut();
-
-                if let Some(readers) = same_base_arrays.get_mut(&key) {
-                    // Zero flags are removed during release.
-                    assert_ne!(*readers, 0);
-
-                    let new_readers = readers.wrapping_add(1);
-
-                    if new_readers <= 0 {
-                        cold();
-                        return Err(BorrowError::AlreadyBorrowed);
-                    }
-
-                    *readers = new_readers;
-                } else {
-                    if same_base_arrays
-                        .iter()
-                        .any(|(other, readers)| key.conflicts(other) && *readers < 0)
-                    {
-                        cold();
-                        return Err(BorrowError::AlreadyBorrowed);
-                    }
-
-                    same_base_arrays.insert(key, 1);
-                }
-            }
-            Entry::Vacant(entry) => {
-                let mut same_base_arrays =
-                    FxHashMap::with_capacity_and_hasher(1, Default::default());
-                same_base_arrays.insert(key, 1);
-                entry.insert(same_base_arrays);
-            }
-        }
-
-        Ok(())
-    }
-
-    fn release(&self, _py: Python, address: *mut u8, key: BorrowKey) {
-        // SAFETY: Having `_py` implies holding the GIL and
-        // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { self.get() };
-
-        let same_base_arrays = borrow_flags.get_mut(&address).unwrap();
-
-        let readers = same_base_arrays.get_mut(&key).unwrap();
-
-        *readers -= 1;
-
-        if *readers == 0 {
-            if same_base_arrays.len() > 1 {
-                same_base_arrays.remove(&key).unwrap();
-            } else {
-                borrow_flags.remove(&address).unwrap();
-            }
-        }
-    }
-
-    fn acquire_mut(
-        &self,
-        _py: Python,
-        address: *mut u8,
-        key: BorrowKey,
-    ) -> Result<(), BorrowError> {
-        // SAFETY: Having `_py` implies holding the GIL and
-        // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { self.get() };
-
-        match borrow_flags.entry(address) {
-            Entry::Occupied(entry) => {
-                let same_base_arrays = entry.into_mut();
-
-                if let Some(writers) = same_base_arrays.get_mut(&key) {
-                    // Zero flags are removed during release.
-                    assert_ne!(*writers, 0);
-
-                    cold();
-                    return Err(BorrowError::AlreadyBorrowed);
-                } else {
-                    if same_base_arrays
-                        .iter()
-                        .any(|(other, writers)| key.conflicts(other) && *writers != 0)
-                    {
-                        cold();
-                        return Err(BorrowError::AlreadyBorrowed);
-                    }
-
-                    same_base_arrays.insert(key, -1);
-                }
-            }
-            Entry::Vacant(entry) => {
-                let mut same_base_arrays =
-                    FxHashMap::with_capacity_and_hasher(1, Default::default());
-                same_base_arrays.insert(key, -1);
-                entry.insert(same_base_arrays);
-            }
-        }
-
-        Ok(())
-    }
-
-    fn release_mut(&self, _py: Python, address: *mut u8, key: BorrowKey) {
-        // SAFETY: Having `_py` implies holding the GIL and
-        // we are not calling into user code which might re-enter this function.
-        let borrow_flags = unsafe { self.get() };
-
-        let same_base_arrays = borrow_flags.get_mut(&address).unwrap();
-
-        if same_base_arrays.len() > 1 {
-            same_base_arrays.remove(&key).unwrap();
-        } else {
-            borrow_flags.remove(&address);
-        }
-    }
-}
-
-static BORROW_FLAGS: BorrowFlags = BorrowFlags::new();
+use shared::{BorrowKey, BORROW_FLAGS};
 
 /// Read-only borrow of an array.
 ///
@@ -441,7 +245,7 @@ where
 {
     pub(crate) fn try_new(array: &'py PyArray<T, D>) -> Result<Self, BorrowError> {
         let address = base_address(array);
-        let key = BorrowKey::from_array(array);
+        let key = borrow_key(array);
 
         BORROW_FLAGS.acquire(array.py(), address, key)?;
 
@@ -642,7 +446,7 @@ where
         }
 
         let address = base_address(array);
-        let key = BorrowKey::from_array(array);
+        let key = borrow_key(array);
 
         BORROW_FLAGS.acquire_mut(array.py(), address, key)?;
 
@@ -813,6 +617,23 @@ fn base_address<T, D>(array: &PyArray<T, D>) -> *mut u8 {
     }
 
     inner(array.py(), array.as_array_ptr())
+}
+
+fn borrow_key<T, D>(array: &PyArray<T, D>) -> BorrowKey
+where
+    T: Element,
+    D: Dimension,
+{
+    let range = data_range(array);
+
+    let data_ptr = array.data() as *mut u8;
+    let gcd_strides = gcd_strides(array.strides());
+
+    BorrowKey {
+        range,
+        data_ptr,
+        gcd_strides,
+    }
 }
 
 fn data_range<T, D>(array: &PyArray<T, D>) -> (*mut u8, *mut u8)
@@ -1110,7 +931,7 @@ mod tests {
                 .downcast::<PyArray2<f64>>()
                 .unwrap();
 
-            let key1 = BorrowKey::from_array(view1);
+            let key1 = borrow_key(view1);
 
             assert_eq!(view1.strides(), &[80, 24]);
             assert_eq!(key1.gcd_strides, 8);
@@ -1121,7 +942,7 @@ mod tests {
                 .downcast::<PyArray2<f64>>()
                 .unwrap();
 
-            let key2 = BorrowKey::from_array(view2);
+            let key2 = borrow_key(view2);
 
             assert_eq!(view2.strides(), &[80, 24]);
             assert_eq!(key2.gcd_strides, 8);
@@ -1132,7 +953,7 @@ mod tests {
                 .downcast::<PyArray2<f64>>()
                 .unwrap();
 
-            let key3 = BorrowKey::from_array(view3);
+            let key3 = borrow_key(view3);
 
             assert_eq!(view3.strides(), &[80, 16]);
             assert_eq!(key3.gcd_strides, 16);
@@ -1143,7 +964,7 @@ mod tests {
                 .downcast::<PyArray2<f64>>()
                 .unwrap();
 
-            let key4 = BorrowKey::from_array(view4);
+            let key4 = borrow_key(view4);
 
             assert_eq!(view4.strides(), &[80, 16]);
             assert_eq!(key4.gcd_strides, 16);
@@ -1154,227 +975,6 @@ mod tests {
 
             // This is a false conflict where all aliasing indices like (0,7) and (2,0) are out of bounds.
             assert!(key1.conflicts(&key2));
-        });
-    }
-
-    #[test]
-    fn borrow_multiple_arrays() {
-        Python::with_gil(|py| {
-            let array1 = PyArray::<f64, _>::zeros(py, 10, false);
-            let array2 = PyArray::<f64, _>::zeros(py, 10, false);
-
-            let base1 = base_address(array1);
-            let base2 = base_address(array2);
-
-            let key1 = BorrowKey::from_array(array1);
-            let _exclusive1 = array1.readwrite();
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base1];
-                assert_eq!(same_base_arrays.len(), 1);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-            }
-
-            let key2 = BorrowKey::from_array(array2);
-            let _shared2 = array2.readonly();
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 2);
-
-                let same_base_arrays = &borrow_flags[&base1];
-                assert_eq!(same_base_arrays.len(), 1);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-
-                let same_base_arrays = &borrow_flags[&base2];
-                assert_eq!(same_base_arrays.len(), 1);
-
-                let flag = same_base_arrays[&key2];
-                assert_eq!(flag, 1);
-            }
-        });
-    }
-
-    #[test]
-    fn borrow_multiple_views() {
-        Python::with_gil(|py| {
-            let array = PyArray::<f64, _>::zeros(py, 10, false);
-            let base = base_address(array);
-
-            let locals = [("array", array)].into_py_dict(py);
-
-            let view1 = py
-                .eval("array[:5]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray1<f64>>()
-                .unwrap();
-
-            let key1 = BorrowKey::from_array(view1);
-            let exclusive1 = view1.readwrite();
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base];
-                assert_eq!(same_base_arrays.len(), 1);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-            }
-
-            let view2 = py
-                .eval("array[5:]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray1<f64>>()
-                .unwrap();
-
-            let key2 = BorrowKey::from_array(view2);
-            let shared2 = view2.readonly();
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base];
-                assert_eq!(same_base_arrays.len(), 2);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-
-                let flag = same_base_arrays[&key2];
-                assert_eq!(flag, 1);
-            }
-
-            let view3 = py
-                .eval("array[5:]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray1<f64>>()
-                .unwrap();
-
-            let key3 = BorrowKey::from_array(view3);
-            let shared3 = view3.readonly();
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base];
-                assert_eq!(same_base_arrays.len(), 2);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-
-                let flag = same_base_arrays[&key2];
-                assert_eq!(flag, 2);
-
-                let flag = same_base_arrays[&key3];
-                assert_eq!(flag, 2);
-            }
-
-            let view4 = py
-                .eval("array[7:]", None, Some(locals))
-                .unwrap()
-                .downcast::<PyArray1<f64>>()
-                .unwrap();
-
-            let key4 = BorrowKey::from_array(view4);
-            let shared4 = view4.readonly();
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base];
-                assert_eq!(same_base_arrays.len(), 3);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-
-                let flag = same_base_arrays[&key2];
-                assert_eq!(flag, 2);
-
-                let flag = same_base_arrays[&key3];
-                assert_eq!(flag, 2);
-
-                let flag = same_base_arrays[&key4];
-                assert_eq!(flag, 1);
-            }
-
-            drop(shared2);
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base];
-                assert_eq!(same_base_arrays.len(), 3);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-
-                let flag = same_base_arrays[&key2];
-                assert_eq!(flag, 1);
-
-                let flag = same_base_arrays[&key3];
-                assert_eq!(flag, 1);
-
-                let flag = same_base_arrays[&key4];
-                assert_eq!(flag, 1);
-            }
-
-            drop(shared3);
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base];
-                assert_eq!(same_base_arrays.len(), 2);
-
-                let flag = same_base_arrays[&key1];
-                assert_eq!(flag, -1);
-
-                assert!(!same_base_arrays.contains_key(&key2));
-
-                assert!(!same_base_arrays.contains_key(&key3));
-
-                let flag = same_base_arrays[&key4];
-                assert_eq!(flag, 1);
-            }
-
-            drop(exclusive1);
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 1);
-
-                let same_base_arrays = &borrow_flags[&base];
-                assert_eq!(same_base_arrays.len(), 1);
-
-                assert!(!same_base_arrays.contains_key(&key1));
-
-                assert!(!same_base_arrays.contains_key(&key2));
-
-                assert!(!same_base_arrays.contains_key(&key3));
-
-                let flag = same_base_arrays[&key4];
-                assert_eq!(flag, 1);
-            }
-
-            drop(shared4);
-
-            {
-                let borrow_flags = unsafe { BORROW_FLAGS.get() };
-                assert_eq!(borrow_flags.len(), 0);
-            }
         });
     }
 

--- a/src/borrow/shared.rs
+++ b/src/borrow/shared.rs
@@ -1,0 +1,425 @@
+use std::cell::UnsafeCell;
+use std::collections::hash_map::Entry;
+
+use num_integer::gcd;
+use pyo3::Python;
+use rustc_hash::FxHashMap;
+
+use crate::cold;
+use crate::error::BorrowError;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BorrowKey {
+    /// exclusive range of lowest and highest address covered by array
+    pub range: (*mut u8, *mut u8),
+    /// the data address on which address computations are based
+    pub data_ptr: *mut u8,
+    /// the greatest common divisor of the strides of the array
+    pub gcd_strides: isize,
+}
+
+impl BorrowKey {
+    pub fn conflicts(&self, other: &Self) -> bool {
+        debug_assert!(self.range.0 <= self.range.1);
+        debug_assert!(other.range.0 <= other.range.1);
+
+        if other.range.0 >= self.range.1 || self.range.0 >= other.range.1 {
+            return false;
+        }
+
+        // The Diophantine equation which describes whether any integers can combine the data pointers and strides of the two arrays s.t.
+        // they yield the same element has a solution if and only if the GCD of all strides divides the difference of the data pointers.
+        //
+        // That solution could be out of bounds which mean that this is still an over-approximation.
+        // It appears sufficient to handle typical cases like the color channels of an image,
+        // but fails when slicing an array with a step size that does not divide the dimension along that axis.
+        //
+        // https://users.rust-lang.org/t/math-for-borrow-checking-numpy-arrays/73303
+        let ptr_diff = unsafe { self.data_ptr.offset_from(other.data_ptr).abs() };
+        let gcd_strides = gcd(self.gcd_strides, other.gcd_strides);
+
+        if ptr_diff % gcd_strides != 0 {
+            return false;
+        }
+
+        // By default, a conflict is assumed as it is the safe choice without actually solving the aliasing equation.
+        true
+    }
+}
+
+type BorrowFlagsInner = FxHashMap<*mut u8, FxHashMap<BorrowKey, isize>>;
+
+pub struct BorrowFlags(UnsafeCell<Option<BorrowFlagsInner>>);
+
+unsafe impl Sync for BorrowFlags {}
+
+impl BorrowFlags {
+    const fn new() -> Self {
+        Self(UnsafeCell::new(None))
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    unsafe fn get(&self) -> &mut BorrowFlagsInner {
+        (*self.0.get()).get_or_insert_with(Default::default)
+    }
+
+    pub fn acquire(
+        &self,
+        _py: Python,
+        address: *mut u8,
+        key: BorrowKey,
+    ) -> Result<(), BorrowError> {
+        // SAFETY: Having `_py` implies holding the GIL and
+        // we are not calling into user code which might re-enter this function.
+        let borrow_flags = unsafe { self.get() };
+
+        match borrow_flags.entry(address) {
+            Entry::Occupied(entry) => {
+                let same_base_arrays = entry.into_mut();
+
+                if let Some(readers) = same_base_arrays.get_mut(&key) {
+                    // Zero flags are removed during release.
+                    assert_ne!(*readers, 0);
+
+                    let new_readers = readers.wrapping_add(1);
+
+                    if new_readers <= 0 {
+                        cold();
+                        return Err(BorrowError::AlreadyBorrowed);
+                    }
+
+                    *readers = new_readers;
+                } else {
+                    if same_base_arrays
+                        .iter()
+                        .any(|(other, readers)| key.conflicts(other) && *readers < 0)
+                    {
+                        cold();
+                        return Err(BorrowError::AlreadyBorrowed);
+                    }
+
+                    same_base_arrays.insert(key, 1);
+                }
+            }
+            Entry::Vacant(entry) => {
+                let mut same_base_arrays =
+                    FxHashMap::with_capacity_and_hasher(1, Default::default());
+                same_base_arrays.insert(key, 1);
+                entry.insert(same_base_arrays);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn release(&self, _py: Python, address: *mut u8, key: BorrowKey) {
+        // SAFETY: Having `_py` implies holding the GIL and
+        // we are not calling into user code which might re-enter this function.
+        let borrow_flags = unsafe { self.get() };
+
+        let same_base_arrays = borrow_flags.get_mut(&address).unwrap();
+
+        let readers = same_base_arrays.get_mut(&key).unwrap();
+
+        *readers -= 1;
+
+        if *readers == 0 {
+            if same_base_arrays.len() > 1 {
+                same_base_arrays.remove(&key).unwrap();
+            } else {
+                borrow_flags.remove(&address).unwrap();
+            }
+        }
+    }
+
+    pub fn acquire_mut(
+        &self,
+        _py: Python,
+        address: *mut u8,
+        key: BorrowKey,
+    ) -> Result<(), BorrowError> {
+        // SAFETY: Having `_py` implies holding the GIL and
+        // we are not calling into user code which might re-enter this function.
+        let borrow_flags = unsafe { self.get() };
+
+        match borrow_flags.entry(address) {
+            Entry::Occupied(entry) => {
+                let same_base_arrays = entry.into_mut();
+
+                if let Some(writers) = same_base_arrays.get_mut(&key) {
+                    // Zero flags are removed during release.
+                    assert_ne!(*writers, 0);
+
+                    cold();
+                    return Err(BorrowError::AlreadyBorrowed);
+                } else {
+                    if same_base_arrays
+                        .iter()
+                        .any(|(other, writers)| key.conflicts(other) && *writers != 0)
+                    {
+                        cold();
+                        return Err(BorrowError::AlreadyBorrowed);
+                    }
+
+                    same_base_arrays.insert(key, -1);
+                }
+            }
+            Entry::Vacant(entry) => {
+                let mut same_base_arrays =
+                    FxHashMap::with_capacity_and_hasher(1, Default::default());
+                same_base_arrays.insert(key, -1);
+                entry.insert(same_base_arrays);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn release_mut(&self, _py: Python, address: *mut u8, key: BorrowKey) {
+        // SAFETY: Having `_py` implies holding the GIL and
+        // we are not calling into user code which might re-enter this function.
+        let borrow_flags = unsafe { self.get() };
+
+        let same_base_arrays = borrow_flags.get_mut(&address).unwrap();
+
+        if same_base_arrays.len() > 1 {
+            same_base_arrays.remove(&key).unwrap();
+        } else {
+            borrow_flags.remove(&address);
+        }
+    }
+}
+
+pub static BORROW_FLAGS: BorrowFlags = BorrowFlags::new();
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pyo3::types::IntoPyDict;
+
+    use crate::array::{PyArray, PyArray1};
+
+    use super::super::{base_address, borrow_key};
+
+    #[test]
+    fn borrow_multiple_arrays() {
+        Python::with_gil(|py| {
+            let array1 = PyArray::<f64, _>::zeros(py, 10, false);
+            let array2 = PyArray::<f64, _>::zeros(py, 10, false);
+
+            let base1 = base_address(array1);
+            let base2 = base_address(array2);
+
+            let key1 = borrow_key(array1);
+            let _exclusive1 = array1.readwrite();
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base1];
+                assert_eq!(same_base_arrays.len(), 1);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+            }
+
+            let key2 = borrow_key(array2);
+            let _shared2 = array2.readonly();
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 2);
+
+                let same_base_arrays = &borrow_flags[&base1];
+                assert_eq!(same_base_arrays.len(), 1);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+
+                let same_base_arrays = &borrow_flags[&base2];
+                assert_eq!(same_base_arrays.len(), 1);
+
+                let flag = same_base_arrays[&key2];
+                assert_eq!(flag, 1);
+            }
+        });
+    }
+
+    #[test]
+    fn borrow_multiple_views() {
+        Python::with_gil(|py| {
+            let array = PyArray::<f64, _>::zeros(py, 10, false);
+            let base = base_address(array);
+
+            let locals = [("array", array)].into_py_dict(py);
+
+            let view1 = py
+                .eval("array[:5]", None, Some(locals))
+                .unwrap()
+                .downcast::<PyArray1<f64>>()
+                .unwrap();
+
+            let key1 = borrow_key(view1);
+            let exclusive1 = view1.readwrite();
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base];
+                assert_eq!(same_base_arrays.len(), 1);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+            }
+
+            let view2 = py
+                .eval("array[5:]", None, Some(locals))
+                .unwrap()
+                .downcast::<PyArray1<f64>>()
+                .unwrap();
+
+            let key2 = borrow_key(view2);
+            let shared2 = view2.readonly();
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base];
+                assert_eq!(same_base_arrays.len(), 2);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+
+                let flag = same_base_arrays[&key2];
+                assert_eq!(flag, 1);
+            }
+
+            let view3 = py
+                .eval("array[5:]", None, Some(locals))
+                .unwrap()
+                .downcast::<PyArray1<f64>>()
+                .unwrap();
+
+            let key3 = borrow_key(view3);
+            let shared3 = view3.readonly();
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base];
+                assert_eq!(same_base_arrays.len(), 2);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+
+                let flag = same_base_arrays[&key2];
+                assert_eq!(flag, 2);
+
+                let flag = same_base_arrays[&key3];
+                assert_eq!(flag, 2);
+            }
+
+            let view4 = py
+                .eval("array[7:]", None, Some(locals))
+                .unwrap()
+                .downcast::<PyArray1<f64>>()
+                .unwrap();
+
+            let key4 = borrow_key(view4);
+            let shared4 = view4.readonly();
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base];
+                assert_eq!(same_base_arrays.len(), 3);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+
+                let flag = same_base_arrays[&key2];
+                assert_eq!(flag, 2);
+
+                let flag = same_base_arrays[&key3];
+                assert_eq!(flag, 2);
+
+                let flag = same_base_arrays[&key4];
+                assert_eq!(flag, 1);
+            }
+
+            drop(shared2);
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base];
+                assert_eq!(same_base_arrays.len(), 3);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+
+                let flag = same_base_arrays[&key2];
+                assert_eq!(flag, 1);
+
+                let flag = same_base_arrays[&key3];
+                assert_eq!(flag, 1);
+
+                let flag = same_base_arrays[&key4];
+                assert_eq!(flag, 1);
+            }
+
+            drop(shared3);
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base];
+                assert_eq!(same_base_arrays.len(), 2);
+
+                let flag = same_base_arrays[&key1];
+                assert_eq!(flag, -1);
+
+                assert!(!same_base_arrays.contains_key(&key2));
+
+                assert!(!same_base_arrays.contains_key(&key3));
+
+                let flag = same_base_arrays[&key4];
+                assert_eq!(flag, 1);
+            }
+
+            drop(exclusive1);
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 1);
+
+                let same_base_arrays = &borrow_flags[&base];
+                assert_eq!(same_base_arrays.len(), 1);
+
+                assert!(!same_base_arrays.contains_key(&key1));
+
+                assert!(!same_base_arrays.contains_key(&key2));
+
+                assert!(!same_base_arrays.contains_key(&key3));
+
+                let flag = same_base_arrays[&key4];
+                assert_eq!(flag, 1);
+            }
+
+            drop(shared4);
+
+            {
+                let borrow_flags = unsafe { BORROW_FLAGS.get() };
+                assert_eq!(borrow_flags.len(), 0);
+            }
+        });
+    }
+}

--- a/src/borrow/shared.rs
+++ b/src/borrow/shared.rs
@@ -127,7 +127,7 @@ fn insert_shared(py: Python) -> PyResult<*const Shared> {
     let capsule: &PyCapsule = match module.getattr("_RUST_NUMPY_BORROW_CHECKING_API") {
         Ok(capsule) => capsule.try_into()?,
         Err(_err) => {
-            let flags = Box::into_raw(Box::new(BorrowFlags::default()));
+            let flags: *mut BorrowFlags = Box::into_raw(Box::default());
 
             let shared = Shared {
                 version: 1,


### PR DESCRIPTION
This places the global state required for dynamic borrow checking of NumPy arrays into a capsule exposed as the numpy.core.multiarray._BORROW_CHECKING_API attribute.
    
This has two benefits: First, all extensions built using rust-numpy will share this global state and hence cooperate in borrow checking. Second, in the future,
other libraries that want to borrow check their access to NumPy array can cooperate using this C-compatible API.

This does not checking the borrow checking implementation at all, but instead of accessing Rust static data, all accesses are funneled through the above-mentioned capsule API with access to it being cached for performance reasons as we already do for the _ARRAY_API and _UFUNC_API capsules.

This means that eventually, the implementation of the borrow checking API could be different from the one the current extension would provide with the adaptors to the C API taking of any differences in e.g. the definition of `BorrowKey`. For now, they will of course usually be the same and this change just adds a huge amount of boiler plate to go from Rust to C-compatible back to Rust.

Closes #359

cc @alex This is not the buffer-oriented protocol change you proposed in ["Buffers on the edge"](https://alexgaynor.net/2022/oct/23/buffers-on-the-edge/), but may be of interested anyway as it is related if limited to NumPy arrays.