### PR TITLE
Freeze the slice container pyclass as it does not need mutable access

### DIFF
--- a/src/slice_container.rs
+++ b/src/slice_container.rs
@@ -4,7 +4,7 @@ use ndarray::{ArrayBase, Dimension, OwnedRepr};
 use pyo3::pyclass;
 
 /// Utility type to safely store `Box<[_]>` or `Vec<_>` on the Python heap
-#[pyclass]
+#[pyclass(frozen)]
 pub(crate) struct PySliceContainer {
     pub(crate) ptr: *mut u8,
     pub(crate) len: usize,


### PR DESCRIPTION
Or rather any access at all.

@davidhewitt @mejrs I think we forgot this when switching from an open-coded `#[pyclass]` to using PyO3's macros to handle the complications implies by the `multiple-pymethods` feature. Maybe yet another data point that frozen-by-default would be a good thing (if the diagnostic of how to gain `&mut self` are good enough).