### PR TITLE
Make sure capsules stay alive when caching pointers into their interior

### DIFF
--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -48,7 +48,8 @@ impl PyArrayAPI {
     unsafe fn get(&self, py: Python, offset: isize) -> *const *const c_void {
         let api = self
             .0
-            .get_or_init(py, || get_numpy_api(py, MOD_NAME, CAPSULE_NAME));
+            .get_or_try_init(py, || get_numpy_api(py, MOD_NAME, CAPSULE_NAME))
+            .expect("Failed to access NumPy array API capsule");
 
         api.offset(offset)
     }

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -23,7 +23,8 @@ impl PyUFuncAPI {
     unsafe fn get(&self, py: Python, offset: isize) -> *const *const c_void {
         let api = self
             .0
-            .get_or_init(py, || get_numpy_api(py, MOD_NAME, CAPSULE_NAME));
+            .get_or_try_init(py, || get_numpy_api(py, MOD_NAME, CAPSULE_NAME))
+            .expect("Failed to access NumPy ufunc API capsule");
 
         api.offset(offset)
     }


### PR DESCRIPTION
While this started as a simple PyO3 API usage modernization, I think we actually need to make sure the capsules stay alive as long as we hold onto pointers into their interior as the modules and hence attributes could theoretically be deleted leaving us with a dangling pointer.

Leaking references to the capsules themselves seemed like the easiest way to avoid the overhead of calling `PyCapsule_Pointer` for each access. This should not be a functional limitation as we never update the cached pointer in any case, i.e. storing `Py<PyCapsule>` would have effectively the same result as the intentional leak.