### PR TITLE
Use GILProtected to make it explicit where we depend on the GIL for synchronization.

### DIFF
--- a/src/slice_container.rs
+++ b/src/slice_container.rs
@@ -5,6 +5,7 @@ use pyo3::pyclass;
 
 /// Utility type to safely store `Box<[_]>` or `Vec<_>` on the Python heap
 #[pyclass(frozen)]
+#[derive(Debug)]
 pub(crate) struct PySliceContainer {
     pub(crate) ptr: *mut u8,
     pub(crate) len: usize,


### PR DESCRIPTION
We can merge this now as GILProtected was released as part of PyO3 0.18.3.