### PR TITLE
Remove unneeded lifetime annotations

### DIFF
--- a/examples/linalg/src/lib.rs
+++ b/examples/linalg/src/lib.rs
@@ -3,9 +3,9 @@ use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
 use pyo3::{exceptions::PyRuntimeError, pymodule, types::PyModule, PyResult, Python};
 
 #[pymodule]
-fn rust_linalg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn rust_linalg(_py: Python, m: &PyModule) -> PyResult<()> {
     #[pyfn(m)]
-    fn inv<'py>(py: Python<'py>, x: PyReadonlyArray2<'py, f64>) -> PyResult<&'py PyArray2<f64>> {
+    fn inv<'py>(py: Python<'py>, x: PyReadonlyArray2<f64>) -> PyResult<&'py PyArray2<f64>> {
         let x = x.as_array();
         let y = x
             .inv()

--- a/examples/parallel/src/lib.rs
+++ b/examples/parallel/src/lib.rs
@@ -6,12 +6,12 @@ use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::{pymodule, types::PyModule, PyResult, Python};
 
 #[pymodule]
-fn rust_parallel(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn rust_parallel(_py: Python, m: &PyModule) -> PyResult<()> {
     #[pyfn(m)]
     fn rows_dot<'py>(
         py: Python<'py>,
-        x: PyReadonlyArray2<'py, f64>,
-        y: PyReadonlyArray1<'py, f64>,
+        x: PyReadonlyArray2<f64>,
+        y: PyReadonlyArray1<f64>,
     ) -> &'py PyArray1<f64> {
         let x = x.as_array();
         let y = y.as_array();

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -14,26 +14,26 @@ use pyo3::{
 };
 
 #[pymodule]
-fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
     // example using generic PyObject
-    fn head(x: ArrayViewD<'_, PyObject>) -> PyResult<PyObject> {
+    fn head(x: ArrayViewD<PyObject>) -> PyResult<PyObject> {
         x.get(0)
             .cloned()
             .ok_or_else(|| PyIndexError::new_err("array index out of range"))
     }
 
     // example using immutable borrows producing a new array
-    fn axpy(a: f64, x: ArrayViewD<'_, f64>, y: ArrayViewD<'_, f64>) -> ArrayD<f64> {
+    fn axpy(a: f64, x: ArrayViewD<f64>, y: ArrayViewD<f64>) -> ArrayD<f64> {
         a * &x + &y
     }
 
     // example using a mutable borrow to modify an array in-place
-    fn mult(a: f64, mut x: ArrayViewMutD<'_, f64>) {
+    fn mult(a: f64, mut x: ArrayViewMutD<f64>) {
         x *= a;
     }
 
     // example using complex numbers
-    fn conj(x: ArrayViewD<'_, Complex64>) -> ArrayD<Complex64> {
+    fn conj(x: ArrayViewD<Complex64>) -> ArrayD<Complex64> {
         x.map(|c| c.conj())
     }
 
@@ -45,7 +45,7 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // wrapper of `head`
     #[pyfn(m)]
     #[pyo3(name = "head")]
-    fn head_py(_py: Python<'_>, x: PyReadonlyArrayDyn<'_, PyObject>) -> PyResult<PyObject> {
+    fn head_py(_py: Python, x: PyReadonlyArrayDyn<PyObject>) -> PyResult<PyObject> {
         head(x.as_array())
     }
 
@@ -55,8 +55,8 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     fn axpy_py<'py>(
         py: Python<'py>,
         a: f64,
-        x: PyReadonlyArrayDyn<'_, f64>,
-        y: PyReadonlyArrayDyn<'_, f64>,
+        x: PyReadonlyArrayDyn<f64>,
+        y: PyReadonlyArrayDyn<f64>,
     ) -> &'py PyArrayDyn<f64> {
         let x = x.as_array();
         let y = y.as_array();
@@ -77,7 +77,7 @@ fn rust_ext(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     #[pyo3(name = "conj")]
     fn conj_py<'py>(
         py: Python<'py>,
-        x: PyReadonlyArrayDyn<'_, Complex64>,
+        x: PyReadonlyArrayDyn<Complex64>,
     ) -> &'py PyArrayDyn<Complex64> {
         conj(x.as_array()).into_pyarray(py)
     }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::useless_vec)]
+
 use std::cmp::Ordering;
 use std::mem::size_of;
 

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::useless_vec)]
-
 use std::cmp::Ordering;
 use std::mem::size_of;
 
@@ -14,6 +12,7 @@ use pyo3::{
 #[test]
 fn to_pyarray_vec() {
     Python::with_gil(|py| {
+        #[allow(clippy::useless_vec)]
         let arr = vec![1, 2, 3].to_pyarray(py);
 
         assert_eq!(arr.shape(), [3]);


### PR DESCRIPTION
It seems like none of these annotations are necessary. After removing them, everything still compiles and works as expected.