### PR TITLE
Fix ignore pattern used to determine test coverage.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,4 +8,4 @@ coverage:
         threshold: 0.25%
 
 ignore:
-  - tests/*.rs
+  - tests/


### PR DESCRIPTION
Since we copied the configuration, we need to copy the fix from https://github.com/PyO3/pyo3/pull/3455