### PR TITLE
migration to pyo3 0.21 new `Bound` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
-pyo3 = { version = "0.20", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.21.0-beta", default-features = false, features = ["gil-refs", "macros"] }
 rustc-hash = "1.1"
 
 [dev-dependencies]
-pyo3 = { version = "0.20", default-features = false, features = ["auto-initialize"] }
+pyo3 = { version = "0.21.0-beta", default-features = false, features = ["auto-initialize", "gil-refs"] }
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 
 [package.metadata.docs.rs]

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_linalg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.20", features = ["extension-module"] }
+pyo3 = { version = "0.21.0-beta", features = ["extension-module"] }
 numpy = { path = "../.." }
 ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
 

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_parallel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.20", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.21.0-beta", features = ["extension-module", "multiple-pymethods"] }
 numpy = { path = "../.." }
 ndarray = { version = "0.15", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.20", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.21.0-beta", features = ["extension-module", "abi3-py37"] }
 numpy = { path = "../.." }
 
 [workspace]

--- a/src/array_like.rs
+++ b/src/array_like.rs
@@ -2,7 +2,12 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use ndarray::{Array1, Dimension, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
-use pyo3::{intern, sync::GILOnceCell, types::PyDict, FromPyObject, Py, PyAny, PyResult};
+use pyo3::{
+    intern,
+    sync::GILOnceCell,
+    types::{PyAnyMethods, PyDict},
+    FromPyObject, Py, PyAny, PyResult,
+};
 
 use crate::sealed::Sealed;
 use crate::{get_array_module, Element, IntoPyArray, PyArray, PyReadonlyArray};

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -9,7 +9,7 @@ use std::os::raw::*;
 use libc::FILE;
 use pyo3::{
     ffi::{self, PyObject, PyTypeObject},
-    once_cell::GILOnceCell,
+    sync::GILOnceCell,
 };
 
 use crate::npyffi::*;

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -2,7 +2,7 @@
 
 use std::os::raw::*;
 
-use pyo3::{ffi::PyObject, once_cell::GILOnceCell};
+use pyo3::{ffi::PyObject, sync::GILOnceCell};
 
 use crate::npyffi::*;
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -5,7 +5,6 @@
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::convert::TryInto;
 use std::fmt;
 use std::mem::size_of;
 use std::os::raw::c_char;

--- a/src/sum_products.rs
+++ b/src/sum_products.rs
@@ -3,7 +3,8 @@ use std::ffi::{CStr, CString};
 use std::ptr::null_mut;
 
 use ndarray::{Dimension, IxDyn};
-use pyo3::{AsPyPointer, FromPyObject, FromPyPointer, PyAny, PyNativeType, PyResult};
+use pyo3::types::PyAnyMethods;
+use pyo3::{AsPyPointer, Bound, FromPyObject, PyNativeType, PyResult};
 
 use crate::array::PyArray;
 use crate::dtype::Element;
@@ -67,7 +68,7 @@ where
     let py = array1.py();
     let obj = unsafe {
         let result = PY_ARRAY_API.PyArray_InnerProduct(py, array1.as_ptr(), array2.as_ptr());
-        PyAny::from_owned_ptr_or_err(py, result)?
+        Bound::from_owned_ptr_or_err(py, result)?
     };
     obj.extract()
 }
@@ -125,7 +126,7 @@ where
     let py = array1.py();
     let obj = unsafe {
         let result = PY_ARRAY_API.PyArray_MatrixProduct(py, array1.as_ptr(), array2.as_ptr());
-        PyAny::from_owned_ptr_or_err(py, result)?
+        Bound::from_owned_ptr_or_err(py, result)?
     };
     obj.extract()
 }
@@ -155,7 +156,7 @@ where
             NPY_CASTING::NPY_NO_CASTING,
             null_mut(),
         );
-        PyAny::from_owned_ptr_or_err(py, result)?
+        Bound::from_owned_ptr_or_err(py, result)?
     };
     obj.extract()
 }

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -61,8 +61,6 @@ use crate::npyffi;
 pub struct PyUntypedArray(PyAny);
 
 unsafe impl PyTypeInfo for PyUntypedArray {
-    type AsRefTarget = Self;
-
     const NAME: &'static str = "PyUntypedArray";
     const MODULE: Option<&'static str> = Some("numpy");
 

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -234,6 +234,7 @@ fn to_pyarray_object_vec() {
     Python::with_gil(|py| {
         let dict = PyDict::new(py);
         let string = PyString::new(py, "Hello:)");
+        #[allow(clippy::useless_vec)] // otherwise we do not test the right trait impl
         let vec = vec![dict.to_object(py), string.to_object(py)];
 
         let arr = vec.to_pyarray(py);


### PR DESCRIPTION
`pyo3` 0.21 is on the final stretch to release, with an initial beta expected in the next few days.

This starts the migration to `pyo3`s new `Bound` API. This initial PR bumps the `pyo3` version, enables the `gil-refs` feature (to suppress most of the deprecation warnings) and adjust the rest to compile and pass the tests again. 

Note:
`PyTypeInfo` needs to be updated to `is_type_of_bound` now, because otherwise `pyo3`s internals will not use the custom implementation, as found in https://github.com/PyO3/pyo3/issues/3929

I've prepared followups migrating different parts of the API in (hopefully) reviewable chunks. Generally I took a similar approach to `pyo3` itself, leaving old API around (for easy migrations) and adding deprecation warnings where necessary.

I'll leave this as a draft until the beta release drops and rebase this than. 



