### PR TITLE
convert `PyArrayDescr` to `Bound` API

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -281,7 +281,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         let src_dtype = array.dtype();
         let dst_dtype = T::get_dtype_bound(ob.py());
         if !src_dtype.is_equiv_to(&dst_dtype) {
-            return Err(TypeError::new(src_dtype.into_gil_ref(), dst_dtype.into_gil_ref()).into());
+            return Err(TypeError::new(src_dtype, dst_dtype).into());
         }
 
         Ok(array)

--- a/src/array_like.rs
+++ b/src/array_like.rs
@@ -164,7 +164,7 @@ where
 
         let kwargs = if C::VAL {
             let kwargs = PyDict::new(py);
-            kwargs.set_item(intern!(py, "dtype"), T::get_dtype(py))?;
+            kwargs.set_item(intern!(py, "dtype"), T::get_dtype_bound(py))?;
             Some(kwargs)
         } else {
             None

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,9 @@
 use std::error::Error;
 use std::fmt;
 
-use pyo3::{exceptions::PyTypeError, Py, PyErr, PyErrArguments, PyObject, Python, ToPyObject};
+use pyo3::{
+    exceptions::PyTypeError, Bound, Py, PyErr, PyErrArguments, PyObject, Python, ToPyObject,
+};
 
 use crate::dtype::PyArrayDescr;
 
@@ -59,13 +61,13 @@ impl_pyerr!(DimensionalityError);
 
 /// Represents that types of the given arrays do not match.
 #[derive(Debug)]
-pub struct TypeError<'a> {
-    from: &'a PyArrayDescr,
-    to: &'a PyArrayDescr,
+pub struct TypeError<'py> {
+    from: Bound<'py, PyArrayDescr>,
+    to: Bound<'py, PyArrayDescr>,
 }
 
-impl<'a> TypeError<'a> {
-    pub(crate) fn new(from: &'a PyArrayDescr, to: &'a PyArrayDescr) -> Self {
+impl<'py> TypeError<'py> {
+    pub(crate) fn new(from: Bound<'py, PyArrayDescr>, to: Bound<'py, PyArrayDescr>) -> Self {
         Self { from, to }
     }
 }
@@ -86,8 +88,8 @@ struct TypeErrorArguments {
 impl PyErrArguments for TypeErrorArguments {
     fn arguments<'py>(self, py: Python<'py>) -> PyObject {
         let err = TypeError {
-            from: self.from.as_ref(py),
-            to: self.to.as_ref(py),
+            from: self.from.into_bound(py),
+            to: self.to.into_bound(py),
         };
 
         err.to_string().to_object(py)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,11 @@ pub use crate::borrow::{
     PyReadwriteArray5, PyReadwriteArray6, PyReadwriteArrayDyn,
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-pub use crate::dtype::{dtype, Complex32, Complex64, Element, PyArrayDescr};
+#[allow(deprecated)]
+pub use crate::dtype::dtype;
+pub use crate::dtype::{
+    dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods,
+};
 pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::strings::{PyFixedString, PyFixedUnicode};

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -98,13 +98,13 @@ impl PyUntypedArray {
     /// # Example
     ///
     /// ```
-    /// use numpy::{dtype, PyArray};
+    /// use numpy::{dtype_bound, PyArray};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
     ///    let array = PyArray::from_vec(py, vec![1_i32, 2, 3]);
     ///
-    ///    assert!(array.dtype().is_equiv_to(dtype::<i32>(py)));
+    ///    assert!(array.dtype().is_equiv_to(dtype_bound::<i32>(py).as_gil_ref()));
     /// });
     /// ```
     ///
@@ -268,13 +268,13 @@ pub trait PyUntypedArrayMethods<'py>: sealed::Sealed {
     /// # Example
     ///
     /// ```
-    /// use numpy::{dtype, PyArray};
+    /// use numpy::{dtype_bound, PyArray};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
     ///    let array = PyArray::from_vec(py, vec![1_i32, 2, 3]);
     ///
-    ///    assert!(array.dtype().is_equiv_to(dtype::<i32>(py)));
+    ///    assert!(array.dtype().is_equiv_to(dtype_bound::<i32>(py).as_gil_ref()));
     /// });
     /// ```
     ///

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -4,12 +4,12 @@ use std::mem::size_of;
 use half::{bf16, f16};
 use ndarray::{array, s, Array1, Dim};
 use numpy::{
-    dtype, get_array_module, npyffi::NPY_ORDER, pyarray, PyArray, PyArray1, PyArray2, PyArrayDescr,
-    PyArrayDyn, PyFixedString, PyFixedUnicode, ToPyArray,
+    dtype_bound, get_array_module, npyffi::NPY_ORDER, pyarray, PyArray, PyArray1, PyArray2,
+    PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyFixedString, PyFixedUnicode, ToPyArray,
 };
 use pyo3::{
     py_run, pyclass, pymethods,
-    types::{IntoPyDict, PyDict, PyList},
+    types::{IntoPyDict, PyAnyMethods, PyDict, PyList},
     IntoPy, Py, PyAny, PyCell, PyResult, Python,
 };
 
@@ -376,13 +376,17 @@ fn dtype_via_python_attribute() {
         let arr = array![[2, 3], [4, 5u32]];
         let pyarr = arr.to_pyarray(py);
 
-        let dt: &PyArrayDescr = py
-            .eval("a.dtype", Some([("a", pyarr)].into_py_dict(py)), None)
+        let dt = py
+            .eval_bound(
+                "a.dtype",
+                Some(&[("a", pyarr)].into_py_dict_bound(py)),
+                None,
+            )
             .unwrap()
-            .downcast()
+            .downcast_into::<PyArrayDescr>()
             .unwrap();
 
-        assert!(dt.is_equiv_to(dtype::<u32>(py)));
+        assert!(dt.is_equiv_to(&dtype_bound::<u32>(py)));
     });
 }
 


### PR DESCRIPTION
Following #411 

This migrates `PyArrayDescr` to the Bound API. This introduces `PyArrayDescrMethods` to implement the methods on Bound<PyArrayDescr>.