### PR TITLE
convert `PyArray` to `Bound` API

### DIFF
--- a/src/array_like.rs
+++ b/src/array_like.rs
@@ -6,9 +6,10 @@ use pyo3::{
     intern,
     sync::GILOnceCell,
     types::{PyAnyMethods, PyDict},
-    FromPyObject, Py, PyAny, PyResult,
+    Bound, FromPyObject, Py, PyAny, PyResult,
 };
 
+use crate::array::PyArrayMethods;
 use crate::sealed::Sealed;
 use crate::{get_array_module, Element, IntoPyArray, PyArray, PyReadonlyArray};
 
@@ -131,12 +132,12 @@ where
 
 impl<'py, T, D, C> FromPyObject<'py> for PyArrayLike<'py, T, D, C>
 where
-    T: Element,
-    D: Dimension,
+    T: Element + 'py,
+    D: Dimension + 'py,
     C: Coerce,
     Vec<T>: FromPyObject<'py>,
 {
-    fn extract(ob: &'py PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if let Ok(array) = ob.downcast::<PyArray<T, D>>() {
             return Ok(Self(array.readonly(), PhantomData));
         }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -5,7 +5,8 @@ use half::{bf16, f16};
 use ndarray::{array, s, Array1, Dim};
 use numpy::{
     dtype_bound, get_array_module, npyffi::NPY_ORDER, pyarray, PyArray, PyArray1, PyArray2,
-    PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyFixedString, PyFixedUnicode, ToPyArray,
+    PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyFixedString, PyFixedUnicode,
+    PyUntypedArrayMethods, ToPyArray,
 };
 use pyo3::{
     py_run, pyclass, pymethods,
@@ -471,6 +472,7 @@ fn to_owned_works() {
     let arr: Py<PyArray1<_>> = Python::with_gil(|py| {
         let arr = PyArray::from_slice(py, &[1_i32, 2, 3]);
 
+        #[allow(deprecated)]
         arr.to_owned()
     });
 


### PR DESCRIPTION
Following #412

This migrates `PyArray` to the Bound API. This introduces `PyArrayMethods` to implement the methods on Bound. The diff is a bit bigger for this one, but most of the code just moved around a bit, so I hope it's still fine.