### PR TITLE
migrate `PyArray` contructors to `Bound` API (Part 1)

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -82,7 +82,7 @@ use crate::untyped_array::{PyUntypedArray, PyUntypedArrayMethods};
 ///
 /// ```
 /// use numpy::PyArray;
-/// use ndarray::{array, Array};
+/// use ndarray::array;
 /// use pyo3::Python;
 ///
 /// Python::with_gil(|py| {
@@ -575,6 +575,15 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         }
     }
 
+    /// Deprecated form of [`PyArray<T, D>::from_owned_array_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by PyArray::from_owned_array_bound in the future"
+    )]
+    pub fn from_owned_array<'py>(py: Python<'py>, arr: Array<T, D>) -> &'py Self {
+        Self::from_owned_array_bound(py, arr).into_gil_ref()
+    }
+
     /// Constructs a NumPy from an [`ndarray::Array`]
     ///
     /// This method uses the internal [`Vec`] of the [`ndarray::Array`] as the base object of the NumPy array.
@@ -582,17 +591,17 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     /// # Example
     ///
     /// ```
-    /// use numpy::PyArray;
+    /// use numpy::{PyArray, PyArrayMethods};
     /// use ndarray::array;
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
-    ///     let pyarray = PyArray::from_owned_array(py, array![[1, 2], [3, 4]]);
+    ///     let pyarray = PyArray::from_owned_array_bound(py, array![[1, 2], [3, 4]]);
     ///
     ///     assert_eq!(pyarray.readonly().as_array(), array![[1, 2], [3, 4]]);
     /// });
     /// ```
-    pub fn from_owned_array<'py>(py: Python<'py>, mut arr: Array<T, D>) -> &'py Self {
+    pub fn from_owned_array_bound(py: Python<'_>, mut arr: Array<T, D>) -> Bound<'_, Self> {
         let (strides, dims) = (arr.npy_strides(), arr.raw_dim());
         let data_ptr = arr.as_mut_ptr();
         unsafe {
@@ -603,7 +612,6 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
                 data_ptr,
                 PySliceContainer::from(arr),
             )
-            .into_gil_ref()
         }
     }
 
@@ -959,6 +967,15 @@ where
 }
 
 impl<D: Dimension> PyArray<PyObject, D> {
+    /// Deprecated form of [`PyArray<T, D>::from_owned_object_array_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by PyArray::from_owned_object_array_bound in the future"
+    )]
+    pub fn from_owned_object_array<'py, T>(py: Python<'py>, arr: Array<Py<T>, D>) -> &'py Self {
+        Self::from_owned_object_array_bound(py, arr).into_gil_ref()
+    }
+
     /// Construct a NumPy array containing objects stored in a [`ndarray::Array`]
     ///
     /// This method uses the internal [`Vec`] of the [`ndarray::Array`] as the base object of the NumPy array.
@@ -968,7 +985,7 @@ impl<D: Dimension> PyArray<PyObject, D> {
     /// ```
     /// use ndarray::array;
     /// use pyo3::{pyclass, Py, Python};
-    /// use numpy::PyArray;
+    /// use numpy::{PyArray, PyArrayMethods};
     ///
     /// #[pyclass]
     /// struct CustomElement {
@@ -988,12 +1005,15 @@ impl<D: Dimension> PyArray<PyObject, D> {
     ///         }).unwrap(),
     ///     ];
     ///
-    ///     let pyarray = PyArray::from_owned_object_array(py, array);
+    ///     let pyarray = PyArray::from_owned_object_array_bound(py, array);
     ///
     ///     assert!(pyarray.readonly().as_array().get(0).unwrap().as_ref(py).is_instance_of::<CustomElement>());
     /// });
     /// ```
-    pub fn from_owned_object_array<'py, T>(py: Python<'py>, mut arr: Array<Py<T>, D>) -> &'py Self {
+    pub fn from_owned_object_array_bound<T>(
+        py: Python<'_>,
+        mut arr: Array<Py<T>, D>,
+    ) -> Bound<'_, Self> {
         let (strides, dims) = (arr.npy_strides(), arr.raw_dim());
         let data_ptr = arr.as_mut_ptr() as *const PyObject;
         unsafe {
@@ -1004,7 +1024,6 @@ impl<D: Dimension> PyArray<PyObject, D> {
                 data_ptr,
                 PySliceContainer::from(arr),
             )
-            .into_gil_ref()
         }
     }
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -93,7 +93,7 @@ where
     type Dim = D;
 
     fn into_pyarray<'py>(self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
-        PyArray::from_owned_array(py, self)
+        PyArray::from_owned_array_bound(py, self).into_gil_ref()
     }
 }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -254,7 +254,7 @@ mod tests {
         types::{PyDict, PyModule},
     };
 
-    use crate::array::PyArray1;
+    use crate::array::{PyArray1, PyArrayMethods};
 
     #[test]
     fn from_python_to_rust() {
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn from_rust_to_python() {
         Python::with_gil(|py| {
-            let array = PyArray1::<Timedelta<units::Minutes>>::zeros(py, 1, false);
+            let array = PyArray1::<Timedelta<units::Minutes>>::zeros_bound(py, 1, false);
 
             *array.readwrite().get_mut(0).unwrap() = Timedelta::<units::Minutes>::from(5);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,8 @@ pub use pyo3;
 pub use nalgebra;
 
 pub use crate::array::{
-    get_array_module, PyArray, PyArray0, PyArray1, PyArray2, PyArray3, PyArray4, PyArray5,
-    PyArray6, PyArrayDyn, PyArrayMethods,
+    get_array_module, PyArray, PyArray0, PyArray0Methods, PyArray1, PyArray2, PyArray3, PyArray4,
+    PyArray5, PyArray6, PyArrayDyn, PyArrayMethods,
 };
 pub use crate::array_like::{
     AllowTypeChange, PyArrayLike, PyArrayLike0, PyArrayLike1, PyArrayLike2, PyArrayLike3,

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -28,11 +28,12 @@ use crate::npyffi;
 /// ```
 /// # use pyo3::prelude::*;
 /// use pyo3::exceptions::PyTypeError;
-/// use numpy::{Element, PyUntypedArray, PyArray1, dtype};
+/// use numpy::{Element, PyUntypedArray, PyArray1, dtype_bound};
+/// use numpy::{PyUntypedArrayMethods, PyArrayMethods, PyArrayDescrMethods};
 ///
 /// #[pyfunction]
-/// fn entry_point(py: Python, array: &PyUntypedArray) -> PyResult<()> {
-///     fn implementation<T: Element>(array: &PyArray1<T>) -> PyResult<()> {
+/// fn entry_point(py: Python<'_>, array: &Bound<'_, PyUntypedArray>) -> PyResult<()> {
+///     fn implementation<T: Element>(array: &Bound<'_, PyArray1<T>>) -> PyResult<()> {
 ///         /* .. */
 ///
 ///         Ok(())
@@ -40,12 +41,12 @@ use crate::npyffi;
 ///
 ///     let element_type = array.dtype();
 ///
-///     if element_type.is_equiv_to(dtype::<f32>(py)) {
-///         let array: &PyArray1<f32> = array.downcast()?;
+///     if element_type.is_equiv_to(&dtype_bound::<f32>(py)) {
+///         let array = array.downcast::<PyArray1<f32>>()?;
 ///
 ///         implementation(array)
-///     } else if element_type.is_equiv_to(dtype::<f64>(py)) {
-///         let array: &PyArray1<f64> = array.downcast()?;
+///     } else if element_type.is_equiv_to(&dtype_bound::<f64>(py)) {
+///         let array = array.downcast::<PyArray1<f64>>()?;
 ///
 ///         implementation(array)
 ///     } else {
@@ -54,8 +55,8 @@ use crate::npyffi;
 /// }
 /// #
 /// # Python::with_gil(|py| {
-/// #   let array = PyArray1::<f64>::zeros(py, 42, false);
-/// #   entry_point(py, array)
+/// #   let array = PyArray1::<f64>::zeros_bound(py, 42, false);
+/// #   entry_point(py, array.as_untyped())
 /// # }).unwrap();
 /// ```
 #[repr(transparent)]
@@ -160,11 +161,11 @@ impl PyUntypedArray {
     /// # Example
     ///
     /// ```
-    /// use numpy::PyArray3;
+    /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
-    ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
+    ///     let arr = PyArray3::<f64>::zeros_bound(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.ndim(), 3);
     /// });
@@ -184,11 +185,11 @@ impl PyUntypedArray {
     /// # Example
     ///
     /// ```
-    /// use numpy::PyArray3;
+    /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
-    ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
+    ///     let arr = PyArray3::<f64>::zeros_bound(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.strides(), &[240, 48, 8]);
     /// });
@@ -216,11 +217,11 @@ impl PyUntypedArray {
     /// # Example
     ///
     /// ```
-    /// use numpy::PyArray3;
+    /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
-    ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
+    ///     let arr = PyArray3::<f64>::zeros_bound(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.shape(), &[4, 5, 6]);
     /// });
@@ -329,11 +330,11 @@ pub trait PyUntypedArrayMethods<'py>: sealed::Sealed {
     /// # Example
     ///
     /// ```
-    /// use numpy::PyArray3;
+    /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
-    ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
+    ///     let arr = PyArray3::<f64>::zeros_bound(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.ndim(), 3);
     /// });
@@ -353,11 +354,11 @@ pub trait PyUntypedArrayMethods<'py>: sealed::Sealed {
     /// # Example
     ///
     /// ```
-    /// use numpy::PyArray3;
+    /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
-    ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
+    ///     let arr = PyArray3::<f64>::zeros_bound(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.strides(), &[240, 48, 8]);
     /// });
@@ -385,11 +386,11 @@ pub trait PyUntypedArrayMethods<'py>: sealed::Sealed {
     /// # Example
     ///
     /// ```
-    /// use numpy::PyArray3;
+    /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
     /// Python::with_gil(|py| {
-    ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
+    ///     let arr = PyArray3::<f64>::zeros_bound(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.shape(), &[4, 5, 6]);
     /// });

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -4,9 +4,11 @@ use std::mem::size_of;
 use half::{bf16, f16};
 use ndarray::{array, s, Array1, Dim};
 use numpy::{
-    dtype_bound, get_array_module, npyffi::NPY_ORDER, pyarray, PyArray, PyArray1, PyArray2,
-    PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods, PyFixedString, PyFixedUnicode,
-    PyUntypedArrayMethods, ToPyArray,
+    array::{PyArray0Methods, PyArrayMethods},
+    dtype_bound, get_array_module,
+    npyffi::NPY_ORDER,
+    pyarray, PyArray, PyArray1, PyArray2, PyArrayDescr, PyArrayDescrMethods, PyArrayDyn,
+    PyFixedString, PyFixedUnicode, PyUntypedArrayMethods, ToPyArray,
 };
 use pyo3::{
     py_run, pyclass, pymethods,
@@ -34,7 +36,7 @@ fn new_c_order() {
     Python::with_gil(|py| {
         let dims = [3, 5];
 
-        let arr = PyArray::<f64, _>::zeros(py, dims, false);
+        let arr = PyArray::<f64, _>::zeros_bound(py, dims, false);
 
         assert!(arr.ndim() == 2);
         assert!(arr.dims() == dims);
@@ -56,7 +58,7 @@ fn new_fortran_order() {
     Python::with_gil(|py| {
         let dims = [3, 5];
 
-        let arr = PyArray::<f64, _>::zeros(py, dims, true);
+        let arr = PyArray::<f64, _>::zeros_bound(py, dims, true);
 
         assert!(arr.ndim() == 2);
         assert!(arr.dims() == dims);
@@ -78,7 +80,7 @@ fn tuple_as_dim() {
     Python::with_gil(|py| {
         let dims = (3, 5);
 
-        let arr = PyArray::<f64, _>::zeros(py, dims, false);
+        let arr = PyArray::<f64, _>::zeros_bound(py, dims, false);
 
         assert!(arr.ndim() == 2);
         assert!(arr.dims() == [3, 5]);
@@ -88,7 +90,7 @@ fn tuple_as_dim() {
 #[test]
 fn rank_zero_array_has_invalid_strides_dimensions() {
     Python::with_gil(|py| {
-        let arr = PyArray::<f64, _>::zeros(py, (), false);
+        let arr = PyArray::<f64, _>::zeros_bound(py, (), false);
 
         assert_eq!(arr.ndim(), 0);
         assert_eq!(arr.strides(), &[]);
@@ -106,7 +108,7 @@ fn zeros() {
     Python::with_gil(|py| {
         let dims = [3, 4];
 
-        let arr = PyArray::<f64, _>::zeros(py, dims, false);
+        let arr = PyArray::<f64, _>::zeros_bound(py, dims, false);
 
         assert!(arr.ndim() == 2);
         assert!(arr.dims() == dims);
@@ -114,7 +116,7 @@ fn zeros() {
         let size = size_of::<f64>() as isize;
         assert!(arr.strides() == [dims[1] as isize * size, size]);
 
-        let arr = PyArray::<f64, _>::zeros(py, dims, true);
+        let arr = PyArray::<f64, _>::zeros_bound(py, dims, true);
 
         assert!(arr.ndim() == 2);
         assert!(arr.dims() == dims);
@@ -137,7 +139,7 @@ fn arange() {
 #[test]
 fn as_array() {
     Python::with_gil(|py| {
-        let pyarr = PyArray::<f64, _>::zeros(py, [3, 2, 4], false).readonly();
+        let pyarr = PyArray::<f64, _>::zeros_bound(py, [3, 2, 4], false).readonly();
         let arr = pyarr.as_array();
 
         assert_eq!(pyarr.shape(), arr.shape());
@@ -171,7 +173,7 @@ fn as_raw_array() {
 #[test]
 fn as_slice() {
     Python::with_gil(|py| {
-        let arr = PyArray::<i32, _>::zeros(py, [3, 2, 4], false);
+        let arr = PyArray::<i32, _>::zeros_bound(py, [3, 2, 4], false);
         assert_eq!(arr.readonly().as_slice().unwrap().len(), 3 * 2 * 4);
 
         let not_contiguous = not_contiguous_array(py);
@@ -183,7 +185,7 @@ fn as_slice() {
 #[test]
 fn is_instance() {
     Python::with_gil(|py| {
-        let arr = PyArray2::<f64>::zeros(py, [3, 5], false);
+        let arr = PyArray2::<f64>::zeros_bound(py, [3, 5], false);
 
         assert!(arr.is_instance_of::<PyArray2<f64>>());
         assert!(!arr.is_instance_of::<PyList>());

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -5,7 +5,7 @@ use half::{bf16, f16};
 use ndarray::{array, s, Array1, Dim};
 use numpy::{
     dtype_bound, get_array_module, npyffi::NPY_ORDER, pyarray, PyArray, PyArray1, PyArray2,
-    PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyFixedString, PyFixedUnicode,
+    PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods, PyFixedString, PyFixedUnicode,
     PyUntypedArrayMethods, ToPyArray,
 };
 use pyo3::{
@@ -487,9 +487,9 @@ fn to_owned_works() {
 fn copy_to_works() {
     Python::with_gil(|py| {
         let arr1 = PyArray::arange(py, 2.0, 5.0, 1.0);
-        let arr2 = unsafe { PyArray::<i64, _>::new(py, [3], false) };
+        let arr2 = unsafe { PyArray::<i64, _>::new_bound(py, [3], false) };
 
-        arr1.copy_to(arr2).unwrap();
+        arr1.copy_to(arr2.as_gil_ref()).unwrap();
 
         assert_eq!(arr2.readonly().as_slice().unwrap(), &[2, 3, 4]);
     });

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -11,7 +11,7 @@ use numpy::{
 use pyo3::{
     py_run, pyclass, pymethods,
     types::{IntoPyDict, PyAnyMethods, PyDict, PyList},
-    IntoPy, Py, PyAny, PyCell, PyResult, Python,
+    Bound, IntoPy, Py, PyAny, PyResult, Python,
 };
 
 fn get_np_locals<'py>(py: Python<'py>) -> &'py PyDict {
@@ -401,10 +401,10 @@ fn borrow_from_array_works() {
     #[pymethods]
     impl Owner {
         #[getter]
-        fn array(this: &PyCell<Self>) -> &PyArray1<f64> {
+        fn array(this: Bound<'_, Self>) -> Bound<'_, PyArray1<f64>> {
             let array = &this.borrow().array;
 
-            unsafe { PyArray1::borrow_from_array(array, this) }
+            unsafe { PyArray1::borrow_from_array_bound(array, this.into_any()) }
         }
     }
 


### PR DESCRIPTION
Following #415 

This migrates `PyArray` constructors to the `Bound` API. I created a commit for each constructor migration. To keep the diff reviewable I will split this over multiple PRs. This starts the migration with `PyArray::{new, borrow_from_array, from_owned_array, zeros}`.

(This also reexports `PyArray0Methods`, which we forgot in #415)