### PR TITLE
deprecate `pyarray!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,25 +152,11 @@ mod doctest {
 #[inline(always)]
 fn cold() {}
 
-/// Create a [`PyArray`] with one, two or three dimensions.
-///
-/// This macro is backed by [`ndarray::array`].
-///
-/// # Example
-///
-/// ```
-/// use numpy::pyo3::Python;
-/// use numpy::ndarray::array;
-/// use numpy::pyarray;
-///
-/// Python::with_gil(|py| {
-///     let array = pyarray![py, [1, 2], [3, 4]];
-///
-///     assert_eq!(
-///         array.readonly().as_array(),
-///         array![[1, 2], [3, 4]]
-///     );
-/// });
+/// Deprecated form of [`pyarray_bound`]
+#[deprecated(
+    since = "0.21.0",
+    note = "will be replace by `pyarray_bound` in the future"
+)]
 #[macro_export]
 macro_rules! pyarray {
     ($py: ident, $([$([$($x:expr),* $(,)*]),+ $(,)*]),+ $(,)*) => {{
@@ -184,5 +170,37 @@ macro_rules! pyarray {
     ($py: ident, $($x:expr),* $(,)*) => {{
         #[allow(deprecated)]
         $crate::IntoPyArray::into_pyarray($crate::array![$($x,)*], $py)
+    }};
+}
+
+/// Create a [`PyArray`] with one, two or three dimensions.
+///
+/// This macro is backed by [`ndarray::array`].
+///
+/// # Example
+///
+/// ```
+/// use numpy::pyo3::Python;
+/// use numpy::ndarray::array;
+/// use numpy::{pyarray_bound, PyArrayMethods};
+///
+/// Python::with_gil(|py| {
+///     let array = pyarray_bound![py, [1, 2], [3, 4]];
+///
+///     assert_eq!(
+///         array.readonly().as_array(),
+///         array![[1, 2], [3, 4]]
+///     );
+/// });
+#[macro_export]
+macro_rules! pyarray_bound {
+    ($py: ident, $([$([$($x:expr),* $(,)*]),+ $(,)*]),+ $(,)*) => {{
+        $crate::IntoPyArray::into_pyarray_bound($crate::array![$([$([$($x,)*],)*],)*], $py)
+    }};
+    ($py: ident, $([$($x:expr),* $(,)*]),+ $(,)*) => {{
+        $crate::IntoPyArray::into_pyarray_bound($crate::array![$([$($x,)*],)*], $py)
+    }};
+    ($py: ident, $($x:expr),* $(,)*) => {{
+        $crate::IntoPyArray::into_pyarray_bound($crate::array![$($x,)*], $py)
     }};
 }

--- a/src/sum_products.rs
+++ b/src/sum_products.rs
@@ -56,11 +56,11 @@ where
 /// Note that this function can either return a scalar...
 ///
 /// ```
-/// use pyo3::{Python, PyNativeType};
-/// use numpy::{inner_bound, pyarray, PyArray0};
+/// use pyo3::Python;
+/// use numpy::{inner_bound, pyarray_bound, PyArray0};
 ///
 /// Python::with_gil(|py| {
-///     let vector = pyarray![py, 1.0, 2.0, 3.0].as_borrowed();
+///     let vector = pyarray_bound![py, 1.0, 2.0, 3.0];
 ///     let result: f64 = inner_bound(&vector, &vector).unwrap();
 ///     assert_eq!(result, 14.0);
 /// });
@@ -69,11 +69,12 @@ where
 /// ...or an array depending on its arguments.
 ///
 /// ```
-/// use pyo3::{Python, Bound, PyNativeType};
-/// use numpy::{inner_bound, pyarray, PyArray0, PyArray0Methods};
+/// use pyo3::{Python, Bound};
+/// use numpy::prelude::*;
+/// use numpy::{inner_bound, pyarray_bound, PyArray0};
 ///
 /// Python::with_gil(|py| {
-///     let vector = pyarray![py, 1, 2, 3].as_borrowed();
+///     let vector = pyarray_bound![py, 1, 2, 3];
 ///     let result: Bound<'_, PyArray0<_>> = inner_bound(&vector, &vector).unwrap();
 ///     assert_eq!(result.item(), 14);
 /// });
@@ -125,13 +126,13 @@ where
 /// Note that this function can either return an array...
 ///
 /// ```
-/// use pyo3::{Python, Bound, PyNativeType};
+/// use pyo3::{Python, Bound};
 /// use ndarray::array;
-/// use numpy::{dot_bound, pyarray, PyArray2, PyArrayMethods};
+/// use numpy::{dot_bound, pyarray_bound, PyArray2, PyArrayMethods};
 ///
 /// Python::with_gil(|py| {
-///     let matrix = pyarray![py, [1, 0], [0, 1]].as_borrowed();
-///     let another_matrix = pyarray![py, [4, 1], [2, 2]].as_borrowed();
+///     let matrix = pyarray_bound![py, [1, 0], [0, 1]];
+///     let another_matrix = pyarray_bound![py, [4, 1], [2, 2]];
 ///
 ///     let result: Bound<'_, PyArray2<_>> = dot_bound(&matrix, &another_matrix).unwrap();
 ///
@@ -145,11 +146,11 @@ where
 /// ...or a scalar depending on its arguments.
 ///
 /// ```
-/// use pyo3::{Python, PyNativeType};
-/// use numpy::{dot_bound, pyarray, PyArray0};
+/// use pyo3::Python;
+/// use numpy::{dot_bound, pyarray_bound, PyArray0};
 ///
 /// Python::with_gil(|py| {
-///     let vector = pyarray![py, 1.0, 2.0, 3.0].as_borrowed();
+///     let vector = pyarray_bound![py, 1.0, 2.0, 3.0];
 ///     let result: f64 = dot_bound(&vector, &vector).unwrap();
 ///     assert_eq!(result, 14.0);
 /// });
@@ -246,13 +247,13 @@ macro_rules! einsum {
 /// # Example
 ///
 /// ```
-/// use pyo3::{Python, Bound, PyNativeType};
+/// use pyo3::{Python, Bound};
 /// use ndarray::array;
-/// use numpy::{einsum_bound, pyarray, PyArray, PyArray2, PyArrayMethods};
+/// use numpy::{einsum_bound, pyarray_bound, PyArray, PyArray2, PyArrayMethods};
 ///
 /// Python::with_gil(|py| {
 ///     let tensor = PyArray::arange_bound(py, 0, 2 * 3 * 4, 1).reshape([2, 3, 4]).unwrap();
-///     let another_tensor = pyarray![py, [20, 30], [40, 50], [60, 70]].as_borrowed();
+///     let another_tensor = pyarray_bound![py, [20, 30], [40, 50], [60, 70]];
 ///
 ///     let result: Bound<'_, PyArray2<_>> = einsum_bound!("ijk,ji->ik", tensor, another_tensor).unwrap();
 ///

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -7,7 +7,7 @@ use numpy::{
     array::{PyArray0Methods, PyArrayMethods},
     dtype_bound, get_array_module,
     npyffi::NPY_ORDER,
-    pyarray, PyArray, PyArray1, PyArray2, PyArrayDescr, PyArrayDescrMethods, PyArrayDyn,
+    pyarray_bound, PyArray, PyArray1, PyArray2, PyArrayDescr, PyArrayDescrMethods, PyArrayDyn,
     PyFixedString, PyFixedUnicode, PyUntypedArrayMethods, ToPyArray,
 };
 use pyo3::{
@@ -349,8 +349,8 @@ fn extract_fail_by_dtype() {
 #[test]
 fn array_cast() {
     Python::with_gil(|py| {
-        let arr_f64 = pyarray![py, [1.5, 2.5, 3.5], [1.5, 2.5, 3.5]];
-        let arr_i32: &PyArray2<i32> = arr_f64.cast(false).unwrap();
+        let arr_f64 = pyarray_bound![py, [1.5, 2.5, 3.5], [1.5, 2.5, 3.5]];
+        let arr_i32 = arr_f64.cast::<i32>(false).unwrap();
 
         assert_eq!(arr_i32.readonly().as_array(), array![[1, 2, 3], [1, 2, 3]]);
     });
@@ -506,7 +506,7 @@ fn copy_to_works() {
 #[test]
 fn get_works() {
     Python::with_gil(|py| {
-        let array = pyarray![py, [[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]];
+        let array = pyarray_bound![py, [[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]];
 
         unsafe {
             assert_eq!(array.get([0, 0, 0]), Some(&1));

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -352,7 +352,7 @@ fn resize_using_exclusive_borrow() {
 #[test]
 fn matrix_from_numpy() {
     Python::with_gil(|py| {
-        let array = numpy::pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+        let array = numpy::pyarray_bound![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
 
         {
             let array = array.readonly();
@@ -390,7 +390,7 @@ fn matrix_from_numpy() {
     });
 
     Python::with_gil(|py| {
-        let array = numpy::pyarray![py, 0, 1, 2];
+        let array = numpy::pyarray_bound![py, 0, 1, 2];
 
         {
             let array = array.readonly();
@@ -425,7 +425,7 @@ fn matrix_from_numpy() {
     });
 
     Python::with_gil(|py| {
-        let array = numpy::pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+        let array = numpy::pyarray_bound![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
         let array = py
             .eval_bound(
                 "a[::-1]",
@@ -443,7 +443,7 @@ fn matrix_from_numpy() {
     });
 
     Python::with_gil(|py| {
-        let array = numpy::pyarray![py, [[0, 1], [2, 3]], [[4, 5], [6, 7]]];
+        let array = numpy::pyarray_bound![py, [[0, 1], [2, 3]], [[4, 5], [6, 7]]];
         let array = py
             .eval_bound(
                 "a[:,:,0]",
@@ -467,7 +467,31 @@ fn matrix_from_numpy() {
     });
 
     Python::with_gil(|py| {
-        let array = numpy::pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+        let array = numpy::pyarray_bound![py, [[0, 1], [2, 3]], [[4, 5], [6, 7]]];
+        let array = py
+            .eval_bound(
+                "a[:,:,0]",
+                Some(&[("a", &array)].into_py_dict_bound(py)),
+                None,
+            )
+            .unwrap()
+            .downcast_into::<PyArray2<i32>>()
+            .unwrap();
+        let array = array.readonly();
+
+        let matrix: nalgebra::MatrixView<
+            '_,
+            i32,
+            nalgebra::Const<2>,
+            nalgebra::Const<2>,
+            nalgebra::Dyn,
+            nalgebra::Dyn,
+        > = array.try_as_matrix().unwrap();
+        assert_eq!(matrix, nalgebra::Matrix2::new(0, 2, 4, 6));
+    });
+
+    Python::with_gil(|py| {
+        let array = numpy::pyarray_bound![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
         let array = array.readonly();
 
         let matrix: Option<

--- a/tests/sum_products.rs
+++ b/tests/sum_products.rs
@@ -1,28 +1,30 @@
 use numpy::prelude::*;
-use numpy::{array, dot_bound, einsum_bound, inner_bound, pyarray, PyArray0, PyArray1, PyArray2};
-use pyo3::{Bound, PyNativeType, Python};
+use numpy::{
+    array, dot_bound, einsum_bound, inner_bound, pyarray_bound, PyArray0, PyArray1, PyArray2,
+};
+use pyo3::{Bound, Python};
 
 #[test]
 fn test_dot() {
     Python::with_gil(|py| {
-        let a = pyarray![py, [1, 0], [0, 1]].as_borrowed();
-        let b = pyarray![py, [4, 1], [2, 2]].as_borrowed();
+        let a = pyarray_bound![py, [1, 0], [0, 1]];
+        let b = pyarray_bound![py, [4, 1], [2, 2]];
         let c: Bound<'_, PyArray2<_>> = dot_bound(&a, &b).unwrap();
         assert_eq!(c.readonly().as_array(), array![[4, 1], [2, 2]]);
 
-        let a = pyarray![py, 1, 2, 3].as_borrowed();
+        let a = pyarray_bound![py, 1, 2, 3];
         let err = dot_bound::<_, _, _, Bound<'_, PyArray2<_>>>(&a, &b).unwrap_err();
         assert!(err.to_string().contains("not aligned"), "{}", err);
 
-        let a = pyarray![py, 1, 2, 3].as_borrowed();
-        let b = pyarray![py, 0, 1, 0].as_borrowed();
+        let a = pyarray_bound![py, 1, 2, 3];
+        let b = pyarray_bound![py, 0, 1, 0];
         let c: Bound<'_, PyArray0<_>> = dot_bound(&a, &b).unwrap();
         assert_eq!(c.item(), 2);
         let c: i32 = dot_bound(&a, &b).unwrap();
         assert_eq!(c, 2);
 
-        let a = pyarray![py, 1.0, 2.0, 3.0].as_borrowed();
-        let b = pyarray![py, 0.0, 0.0, 0.0].as_borrowed();
+        let a = pyarray_bound![py, 1.0, 2.0, 3.0];
+        let b = pyarray_bound![py, 0.0, 0.0, 0.0];
         let c: f64 = dot_bound(&a, &b).unwrap();
         assert_eq!(c, 0.0);
     });
@@ -31,24 +33,24 @@ fn test_dot() {
 #[test]
 fn test_inner() {
     Python::with_gil(|py| {
-        let a = pyarray![py, 1, 2, 3].as_borrowed();
-        let b = pyarray![py, 0, 1, 0].as_borrowed();
+        let a = pyarray_bound![py, 1, 2, 3];
+        let b = pyarray_bound![py, 0, 1, 0];
         let c: Bound<'_, PyArray0<_>> = inner_bound(&a, &b).unwrap();
         assert_eq!(c.item(), 2);
         let c: i32 = inner_bound(&a, &b).unwrap();
         assert_eq!(c, 2);
 
-        let a = pyarray![py, 1.0, 2.0, 3.0].as_borrowed();
-        let b = pyarray![py, 0.0, 0.0, 0.0].as_borrowed();
+        let a = pyarray_bound![py, 1.0, 2.0, 3.0];
+        let b = pyarray_bound![py, 0.0, 0.0, 0.0];
         let c: f64 = inner_bound(&a, &b).unwrap();
         assert_eq!(c, 0.0);
 
-        let a = pyarray![py, [1, 0], [0, 1]].as_borrowed();
-        let b = pyarray![py, [4, 1], [2, 2]].as_borrowed();
+        let a = pyarray_bound![py, [1, 0], [0, 1]];
+        let b = pyarray_bound![py, [4, 1], [2, 2]];
         let c: Bound<'_, PyArray2<_>> = inner_bound(&a, &b).unwrap();
         assert_eq!(c.readonly().as_array(), array![[4, 2], [1, 2]]);
 
-        let a = pyarray![py, 1, 2, 3].as_borrowed();
+        let a = pyarray_bound![py, 1, 2, 3];
         let err = inner_bound::<_, _, _, Bound<'_, PyArray2<_>>>(&a, &b).unwrap_err();
         assert!(err.to_string().contains("not aligned"), "{}", err);
     });
@@ -60,8 +62,8 @@ fn test_einsum() {
         let a = PyArray1::<i32>::arange_bound(py, 0, 25, 1)
             .reshape([5, 5])
             .unwrap();
-        let b = pyarray![py, 0, 1, 2, 3, 4].as_borrowed();
-        let c = pyarray![py, [0, 1, 2], [3, 4, 5]].as_borrowed();
+        let b = pyarray_bound![py, 0, 1, 2, 3, 4];
+        let c = pyarray_bound![py, [0, 1, 2], [3, 4, 5]];
 
         let d: Bound<'_, PyArray0<_>> = einsum_bound!("ii", a).unwrap();
         assert_eq!(d.item(), 60);


### PR DESCRIPTION
This migrates the `pyarray!` macro and is the final piece of the migration to the `Bound` API of pyo3 0.21 🎉 