### PR TITLE
Bump py03

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ pyo3 = { version = "0.22.0", default-features = false, features = ["macros"] }
 rustc-hash = "1.1"
 
 [dev-dependencies]
-pyo3 = { version = "0.21.0", default-features = false, features = ["auto-initialize"] }
+pyo3 = { version = "0.22.0", default-features = false, features = ["auto-initialize"] }
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
-pyo3 = { version = "0.21.0", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.22.0", default-features = false, features = ["macros"] }
 rustc-hash = "1.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Bumps py03 to 0.22.0

https://github.com/PyO3/pyo3/releases/tag/v0.22.0