### PR TITLE
Update pyo3 to 0.22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,16 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
-pyo3 = { version = "0.21.0", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.22.0", default-features = false, features = ["macros", "py-clone"] }
 rustc-hash = "1.1"
 
 [dev-dependencies]
-pyo3 = { version = "0.21.0", default-features = false, features = ["auto-initialize"] }
+pyo3 = { version = "0.22.0", default-features = false, features = ["auto-initialize"] }
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[features]
+default = ["gil-refs"]
+"gil-refs" = ["pyo3/gil-refs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,4 @@ nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 all-features = true
 
 [features]
-default = ["gil-refs"]
-"gil-refs" = ["pyo3/gil-refs"]
+gil-refs = ["pyo3/gil-refs"]

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -41,10 +41,7 @@ pub trait IntoPyArray: Sized {
     type Dim: Dimension;
 
     /// Deprecated form of [`IntoPyArray::into_pyarray_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `IntoPyArray::into_pyarray_bound` in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     fn into_pyarray<'py>(self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         Self::into_pyarray_bound(self, py).into_gil_ref()
     }
@@ -152,10 +149,7 @@ pub trait ToPyArray {
     type Dim: Dimension;
 
     /// Deprecated form of [`ToPyArray::to_pyarray_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `ToPyArray::to_pyarray_bound` in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     fn to_pyarray<'py>(&self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         Self::to_pyarray_bound(self, py).into_gil_ref()
     }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -241,7 +241,7 @@ impl TypeDescriptors {
             }
         };
 
-        dtype.clone().into_bound(py)
+        dtype.bind(py).to_owned()
     }
 }
 

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -805,6 +805,7 @@ mod tests {
     use super::*;
 
     use pyo3::{py_run, types::PyTypeMethods};
+    use pyo3::types::PyString;
 
     use crate::npyffi::NPY_NEEDS_PYAPI;
 
@@ -831,7 +832,7 @@ mod tests {
 
     #[test]
     fn test_dtype_names() {
-        fn type_name<'py, T: Element>(py: Python<'py>) -> String {
+        fn type_name<T: Element>(py: Python) -> Bound<PyString> {
             dtype_bound::<T>(py).typeobj().qualname().unwrap()
         }
         Python::with_gil(|py| {

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -12,11 +12,12 @@ use pyo3::{
     ffi::{self, PyTuple_Size},
     pyobject_native_type_extract, pyobject_native_type_named,
     types::{PyAnyMethods, PyDict, PyDictMethods, PyTuple, PyType},
-    AsPyPointer, Borrowed, Bound, PyAny, PyNativeType, PyObject, PyResult, PyTypeInfo, Python,
-    ToPyObject,
+    Borrowed, Bound, PyAny, PyObject, PyResult, PyTypeInfo, Python, ToPyObject,
 };
 #[cfg(feature = "half")]
 use pyo3::{sync::GILOnceCell, Py};
+#[cfg(feature = "gil-refs")]
+use pyo3::{AsPyPointer, PyNativeType};
 
 use crate::npyffi::{
     NpyTypes, PyArray_Descr, NPY_ALIGNED_STRUCT, NPY_BYTEORDER_CHAR, NPY_ITEM_HASOBJECT, NPY_TYPES,
@@ -61,6 +62,7 @@ unsafe impl PyTypeInfo for PyArrayDescr {
         unsafe { PY_ARRAY_API.get_type_object(py, NpyTypes::PyArrayDescr_Type) }
     }
 
+    #[cfg(feature = "gil-refs")]
     fn is_type_of(ob: &PyAny) -> bool {
         unsafe { ffi::PyObject_TypeCheck(ob.as_ptr(), Self::type_object_raw(ob.py())) > 0 }
     }
@@ -69,10 +71,7 @@ unsafe impl PyTypeInfo for PyArrayDescr {
 pyobject_native_type_extract!(PyArrayDescr);
 
 /// Returns the type descriptor ("dtype") for a registered type.
-#[deprecated(
-    since = "0.21.0",
-    note = "This will be replaced by `dtype_bound` in the future."
-)]
+#[cfg(feature = "gil-refs")]
 pub fn dtype<'py, T: Element>(py: Python<'py>) -> &'py PyArrayDescr {
     T::get_dtype_bound(py).into_gil_ref()
 }
@@ -83,18 +82,6 @@ pub fn dtype_bound<'py, T: Element>(py: Python<'py>) -> Bound<'py, PyArrayDescr>
 }
 
 impl PyArrayDescr {
-    /// Creates a new type descriptor ("dtype") object from an arbitrary object.
-    ///
-    /// Equivalent to invoking the constructor of [`numpy.dtype`][dtype].
-    ///
-    /// [dtype]: https://numpy.org/doc/stable/reference/generated/numpy.dtype.html
-    #[deprecated(
-        since = "0.21.0",
-        note = "This will be replace by `new_bound` in the future."
-    )]
-    pub fn new<'py, T: ToPyObject + ?Sized>(py: Python<'py>, ob: &T) -> PyResult<&'py Self> {
-        Self::new_bound(py, ob).map(Bound::into_gil_ref)
-    }
     /// Creates a new type descriptor ("dtype") object from an arbitrary object.
     ///
     /// Equivalent to invoking the constructor of [`numpy.dtype`][dtype].
@@ -118,49 +105,14 @@ impl PyArrayDescr {
         inner(py, ob.to_object(py))
     }
 
-    /// Returns `self` as `*mut PyArray_Descr`.
-    pub fn as_dtype_ptr(&self) -> *mut PyArray_Descr {
-        self.as_borrowed().as_dtype_ptr()
-    }
-
-    /// Returns `self` as `*mut PyArray_Descr` while increasing the reference count.
-    ///
-    /// Useful in cases where the descriptor is stolen by the API.
-    pub fn into_dtype_ptr(&self) -> *mut PyArray_Descr {
-        self.as_borrowed().to_owned().into_dtype_ptr()
-    }
-
-    /// Shortcut for creating a type descriptor of `object` type.
-    #[deprecated(
-        since = "0.21.0",
-        note = "This will be replaced by `object_bound` in the future."
-    )]
-    pub fn object<'py>(py: Python<'py>) -> &'py Self {
-        Self::object_bound(py).into_gil_ref()
-    }
-
     /// Shortcut for creating a type descriptor of `object` type.
     pub fn object_bound(py: Python<'_>) -> Bound<'_, Self> {
         Self::from_npy_type(py, NPY_TYPES::NPY_OBJECT)
     }
 
     /// Returns the type descriptor for a registered type.
-    #[deprecated(
-        since = "0.21.0",
-        note = "This will be replaced by `of_bound` in the future."
-    )]
-    pub fn of<'py, T: Element>(py: Python<'py>) -> &'py Self {
-        Self::of_bound::<T>(py).into_gil_ref()
-    }
-
-    /// Returns the type descriptor for a registered type.
     pub fn of_bound<'py, T: Element>(py: Python<'py>) -> Bound<'py, Self> {
         T::get_dtype_bound(py)
-    }
-
-    /// Returns true if two type descriptors are equivalent.
-    pub fn is_equiv_to(&self, other: &Self) -> bool {
-        self.as_borrowed().is_equiv_to(&other.as_borrowed())
     }
 
     fn from_npy_type<'py>(py: Python<'py>, npy_type: NPY_TYPES) -> Bound<'py, Self> {
@@ -175,6 +127,45 @@ impl PyArrayDescr {
             let descr = PY_ARRAY_API.PyArray_DescrNewFromType(py, npy_type as _);
             Bound::from_owned_ptr(py, descr.cast()).downcast_into_unchecked()
         }
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PyArrayDescr {
+    /// Creates a new type descriptor ("dtype") object from an arbitrary object.
+    ///
+    /// Equivalent to invoking the constructor of [`numpy.dtype`][dtype].
+    ///
+    /// [dtype]: https://numpy.org/doc/stable/reference/generated/numpy.dtype.html
+    pub fn new<'py, T: ToPyObject + ?Sized>(py: Python<'py>, ob: &T) -> PyResult<&'py Self> {
+        Self::new_bound(py, ob).map(Bound::into_gil_ref)
+    }
+
+    /// Returns `self` as `*mut PyArray_Descr`.
+    pub fn as_dtype_ptr(&self) -> *mut PyArray_Descr {
+        self.as_borrowed().as_dtype_ptr()
+    }
+
+    /// Returns `self` as `*mut PyArray_Descr` while increasing the reference count.
+    ///
+    /// Useful in cases where the descriptor is stolen by the API.
+    pub fn into_dtype_ptr(&self) -> *mut PyArray_Descr {
+        self.as_borrowed().to_owned().into_dtype_ptr()
+    }
+
+    /// Shortcut for creating a type descriptor of `object` type.
+    pub fn object<'py>(py: Python<'py>) -> &'py Self {
+        Self::object_bound(py).into_gil_ref()
+    }
+
+    /// Returns the type descriptor for a registered type.
+    pub fn of<'py, T: Element>(py: Python<'py>) -> &'py Self {
+        Self::of_bound::<T>(py).into_gil_ref()
+    }
+
+    /// Returns true if two type descriptors are equivalent.
+    pub fn is_equiv_to(&self, other: &Self) -> bool {
+        self.as_borrowed().is_equiv_to(&other.as_borrowed())
     }
 
     /// Returns the [array scalar][arrays-scalars] corresponding to this type descriptor.
@@ -681,10 +672,7 @@ pub unsafe trait Element: Clone + Send {
     const IS_COPY: bool;
 
     /// Returns the associated type descriptor ("dtype") for the given element type.
-    #[deprecated(
-        since = "0.21.0",
-        note = "This will be replaced by `get_dtype_bound` in the future."
-    )]
+    #[cfg(feature = "gil-refs")]
     fn get_dtype<'py>(py: Python<'py>) -> &'py PyArrayDescr {
         Self::get_dtype_bound(py).into_gil_ref()
     }
@@ -804,8 +792,8 @@ unsafe impl Element for PyObject {
 mod tests {
     use super::*;
 
-    use pyo3::{py_run, types::PyTypeMethods};
     use pyo3::types::PyString;
+    use pyo3::{py_run, types::PyTypeMethods};
 
     use crate::npyffi::NPY_NEEDS_PYAPI;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::dtype::{
 pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::strings::{PyFixedString, PyFixedUnicode};
-#[allow(deprecated)]
+#[cfg(feature = "gil-refs")]
 pub use crate::sum_products::{dot, einsum, inner};
 pub use crate::sum_products::{dot_bound, einsum_bound, inner_bound};
 pub use crate::untyped_array::{PyUntypedArray, PyUntypedArrayMethods};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub use crate::borrow::{
     PyReadwriteArray5, PyReadwriteArray6, PyReadwriteArrayDyn,
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-#[allow(deprecated)]
+#[cfg(feature = "gil-refs")]
 pub use crate::dtype::dtype;
 pub use crate::dtype::{
     dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -190,7 +190,7 @@ impl TypeDescriptors {
             }
         };
 
-        dtype.clone().into_bound(py)
+        dtype.bind(py).to_owned()
     }
 }
 

--- a/src/sum_products.rs
+++ b/src/sum_products.rs
@@ -4,7 +4,9 @@ use std::ptr::null_mut;
 
 use ndarray::{Dimension, IxDyn};
 use pyo3::types::PyAnyMethods;
-use pyo3::{Borrowed, Bound, FromPyObject, PyNativeType, PyResult};
+#[cfg(feature = "gil-refs")]
+use pyo3::PyNativeType;
+use pyo3::{Borrowed, Bound, FromPyObject, PyResult};
 
 use crate::array::PyArray;
 use crate::dtype::Element;
@@ -13,6 +15,7 @@ use crate::npyffi::{array::PY_ARRAY_API, NPY_CASTING, NPY_ORDER};
 /// Return value of a function that can yield either an array or a scalar.
 pub trait ArrayOrScalar<'py, T>: FromPyObject<'py> {}
 
+#[cfg(feature = "gil-refs")]
 impl<'py, T, D> ArrayOrScalar<'py, T> for &'py PyArray<T, D>
 where
     T: Element,
@@ -30,10 +33,7 @@ where
 impl<'py, T> ArrayOrScalar<'py, T> for T where T: Element + FromPyObject<'py> {}
 
 /// Deprecated form of [`inner_bound`]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `inner_bound` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 pub fn inner<'py, T, DIN1, DIN2, OUT>(
     array1: &'py PyArray<T, DIN1>,
     array2: &'py PyArray<T, DIN2>,
@@ -100,10 +100,7 @@ where
 }
 
 /// Deprecated form of [`dot_bound`]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `dot_bound` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 pub fn dot<'py, T, DIN1, DIN2, OUT>(
     array1: &'py PyArray<T, DIN1>,
     array2: &'py PyArray<T, DIN2>,
@@ -176,10 +173,7 @@ where
 }
 
 /// Deprecated form of [`einsum_bound`]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `einsum_bound` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 pub fn einsum<'py, T, OUT>(subscripts: &str, arrays: &[&'py PyArray<T, IxDyn>]) -> PyResult<OUT>
 where
     T: Element,
@@ -226,10 +220,7 @@ where
 }
 
 /// Deprecated form of [`einsum_bound!`][crate::einsum_bound!]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `einsum_bound!` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 #[macro_export]
 macro_rules! einsum {
     ($subscripts:literal $(,$array:ident)+ $(,)*) => {{

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -3,9 +3,11 @@
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html
 use std::slice;
 
+#[cfg(feature = "gil-refs")]
+use pyo3::PyNativeType;
 use pyo3::{
     ffi, pyobject_native_type_extract, pyobject_native_type_named, types::PyAnyMethods,
-    AsPyPointer, Bound, IntoPy, PyAny, PyNativeType, PyObject, PyTypeInfo, Python,
+    AsPyPointer, Bound, IntoPy, PyAny, PyObject, PyTypeInfo, Python,
 };
 
 use crate::array::{PyArray, PyArrayMethods};
@@ -85,6 +87,7 @@ impl IntoPy<PyObject> for PyUntypedArray {
 
 pyobject_native_type_extract!(PyUntypedArray);
 
+#[cfg(feature = "gil-refs")]
 impl PyUntypedArray {
     /// Returns a raw pointer to the underlying [`PyArrayObject`][npyffi::PyArrayObject].
     #[inline]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -259,6 +259,7 @@ fn from_vec3_ragged() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_as_fixed() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -273,6 +274,7 @@ fn extract_as_fixed() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_as_dyn() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -294,6 +296,7 @@ fn extract_as_dyn() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_fail_by_check() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -311,6 +314,7 @@ fn extract_fail_by_check() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_fail_by_dim() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -328,6 +332,7 @@ fn extract_fail_by_dim() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_fail_by_dtype() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -474,6 +479,7 @@ fn unbind_works() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn to_owned_works() {
     let arr: Py<PyArray1<_>> = Python::with_gil(|py| {
         let arr = PyArray::from_slice_bound(py, &[1_i32, 2, 3]);


### PR DESCRIPTION
This is the first iteration of the process to update to pyo3 0.22. The first step is to make the current code compile against the new version. In following MR we should feature gate the deprecated gil-refs api's used and implement every method against the Bound wrapper.