### PR TITLE
Update pyo3 to 0.22.0 (without "py-clone")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Bump MSRV to 1.63. ([#450](https://github.com/PyO3/rust-numpy/pull/450))
   - Add `permute` and `transpose` methods for changing the order of axes of a `PyArray`. ([#428](https://github.com/PyO3/rust-numpy/pull/428))
   - Add support for NumPy v2 which had a number of changes to the [C API](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#c-api-changes). ([#442](https://github.com/PyO3/rust-numpy/pull/442))
+  - Bumped pyo3 dependency to v0.22.0 which required the addition of several new methods to the `Element` trait. ([#435](https://github.com/PyO3/rust-numpy/pull/435))
 
 - v0.21.0
   - Migrate to the new `Bound` API introduced by PyO3 0.21. ([#410](https://github.com/PyO3/rust-numpy/pull/410)) ([#411](https://github.com/PyO3/rust-numpy/pull/411)) ([#412](https://github.com/PyO3/rust-numpy/pull/412)) ([#415](https://github.com/PyO3/rust-numpy/pull/415)) ([#416](https://github.com/PyO3/rust-numpy/pull/416)) ([#418](https://github.com/PyO3/rust-numpy/pull/418)) ([#419](https://github.com/PyO3/rust-numpy/pull/419)) ([#420](https://github.com/PyO3/rust-numpy/pull/420)) ([#421](https://github.com/PyO3/rust-numpy/pull/421)) ([#422](https://github.com/PyO3/rust-numpy/pull/422))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,4 @@ nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 all-features = true
 
 [features]
-default = ["gil-refs"]
-"gil-refs" = ["pyo3/gil-refs"]
+gil-refs = ["pyo3/gil-refs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,16 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
-pyo3 = { version = "0.21.0", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.22.0", default-features = false, features = ["macros"] }
 rustc-hash = "1.1"
 
 [dev-dependencies]
-pyo3 = { version = "0.21.0", default-features = false, features = ["auto-initialize"] }
+pyo3 = { version = "0.22.0", default-features = false, features = ["auto-initialize"] }
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[features]
+default = ["gil-refs"]
+"gil-refs" = ["pyo3/gil-refs"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ rust-numpy
 ===========
 [![Actions Status](https://github.com/PyO3/rust-numpy/workflows/CI/badge.svg)](https://github.com/PyO3/rust-numpy/actions)
 [![Crate](https://img.shields.io/crates/v/numpy.svg)](https://crates.io/crates/numpy)
-[![Minimum rustc 1.48](https://img.shields.io/badge/rustc-1.48+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Minimum rustc 1.63](https://img.shields.io/badge/rustc-1.63+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Documentation](https://docs.rs/numpy/badge.svg)](https://docs.rs/numpy)
 [![codecov](https://codecov.io/gh/PyO3/rust-numpy/branch/main/graph/badge.svg)](https://codecov.io/gh/PyO3/rust-numpy)
 
@@ -13,7 +13,7 @@ Rust bindings for the NumPy C-API.
 - [Current main](https://pyo3.github.io/rust-numpy)
 
 ## Requirements
-- Rust >= 1.48.0
+- Rust >= 1.63.0
   - Basically, our MSRV follows the one of [PyO3](https://github.com/PyO3/pyo3)
 - Python >= 3.7
   - Python 3.6 support was dropped from 0.16
@@ -38,7 +38,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = { version = "0.22", features = ["extension-module"] }
 numpy = "0.21"
 ```
 
@@ -93,7 +93,7 @@ fn rust_ext<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()> {
 name = "numpy-test"
 
 [dependencies]
-pyo3 = { version = "0.21", features = ["auto-initialize"] }
+pyo3 = { version = "0.22", features = ["auto-initialize"] }
 numpy = "0.21"
 ```
 

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_linalg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21.0", features = ["extension-module"] }
+pyo3 = { version = "0.22.0", features = ["extension-module"] }
 numpy = { path = "../.." }
 ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
 

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_parallel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21.0", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.22.0", features = ["extension-module", "multiple-pymethods"] }
 numpy = { path = "../.." }
 ndarray = { version = "0.16", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21.0", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.22.0", features = ["extension-module", "abi3-py37"] }
 numpy = { path = "../.." }
 
 [workspace]

--- a/examples/simple/src/lib.rs
+++ b/examples/simple/src/lib.rs
@@ -16,9 +16,9 @@ use pyo3::{
 #[pymodule]
 fn rust_ext<'py>(m: &Bound<'py, PyModule>) -> PyResult<()> {
     // example using generic PyObject
-    fn head(x: ArrayViewD<'_, PyObject>) -> PyResult<PyObject> {
+    fn head(py: Python<'_>, x: ArrayViewD<'_, PyObject>) -> PyResult<PyObject> {
         x.get(0)
-            .cloned()
+            .map(|obj| obj.clone_ref(py))
             .ok_or_else(|| PyIndexError::new_err("array index out of range"))
     }
 
@@ -49,7 +49,7 @@ fn rust_ext<'py>(m: &Bound<'py, PyModule>) -> PyResult<()> {
     #[pyfn(m)]
     #[pyo3(name = "head")]
     fn head_py<'py>(x: PyReadonlyArrayDyn<'py, PyObject>) -> PyResult<PyObject> {
-        head(x.as_array())
+        head(x.py(), x.as_array())
     }
 
     // wrapper of `axpy`

--- a/src/array.rs
+++ b/src/array.rs
@@ -923,6 +923,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
 }
 
 #[cfg(feature = "nalgebra")]
+#[cfg(feature = "gil-refs")]
 impl<N, D> PyArray<N, D>
 where
     N: nalgebra::Scalar + Element,

--- a/src/array.rs
+++ b/src/array.rs
@@ -1473,7 +1473,7 @@ unsafe fn clone_elements<T: Element>(py: Python<'_>, elems: &[T], data_ptr: &mut
         *data_ptr = data_ptr.add(elems.len());
     } else {
         for elem in elems {
-            data_ptr.write(elem.py_clone(py));
+            data_ptr.write(elem.clone_ref(py));
             *data_ptr = data_ptr.add(1);
         }
     }
@@ -2205,7 +2205,7 @@ impl<'py, T, D> PyArrayMethods<'py, T, D> for Bound<'py, PyArray<T, D>> {
         Idx: NpyIndex<Dim = D>,
     {
         let element = unsafe { self.get(index) };
-        element.map(|elem| elem.py_clone(self.py()))
+        element.map(|elem| elem.clone_ref(self.py()))
     }
 
     fn to_dyn(&self) -> &Bound<'py, PyArray<T, IxDyn>> {

--- a/src/array.rs
+++ b/src/array.rs
@@ -229,6 +229,7 @@ impl<T, D> PyArray<T, D> {
     ///     assert_eq!(array.bind(py).readonly().as_slice().unwrap(), [0.0; 5]);
     /// });
     /// ```
+    #[deprecated(since = "0.21.0", note = "use Bound::unbind() instead")]
     pub fn to_owned(&self) -> Py<Self> {
         unsafe { Py::from_borrowed_ptr(self.py(), self.as_ptr()) }
     }
@@ -238,6 +239,7 @@ impl<T, D> PyArray<T, D> {
     /// # Safety
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_owned_ptr_or_opt`] and inherits its safety contract.
+    #[deprecated(since = "0.21.0", note = "use Bound::from_owned_ptr() instead")]
     pub unsafe fn from_owned_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
         #![allow(deprecated)]
         py.from_owned_ptr(ptr)
@@ -248,6 +250,7 @@ impl<T, D> PyArray<T, D> {
     /// # Safety
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_borrowed_ptr_or_opt`] and inherits its safety contract.
+    #[deprecated(since = "0.21.0", note = "use Bound::from_borrowed_ptr() instead")]
     pub unsafe fn from_borrowed_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
         #![allow(deprecated)]
         py.from_borrowed_ptr(ptr)
@@ -577,6 +580,10 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     ///
     /// # Safety
     /// Same as [`PyArray<T, D>::new_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `PyArray::new_bound` in the future"
+    )]
     pub unsafe fn new<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &Self
     where
         ID: IntoDimension<Dim = D>,
@@ -588,6 +595,10 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     ///
     /// # Safety
     /// Same as [`PyArray<T, D>::borrow_from_array_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `PyArray::borrow_from_array_bound` in the future"
+    )]
     pub unsafe fn borrow_from_array<'py, S>(
         array: &ArrayBase<S, D>,
         container: &'py PyAny,
@@ -599,6 +610,10 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     }
 
     /// Deprecated form of [`PyArray<T, D>::zeros_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `PyArray::zeros_bound` in the future"
+    )]
     pub fn zeros<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &Self
     where
         ID: IntoDimension<Dim = D>,
@@ -641,6 +656,10 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     }
 
     /// Deprecated form of [`PyArray<T, D>::from_owned_array_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by PyArray::from_owned_array_bound in the future"
+    )]
     pub fn from_owned_array<'py>(py: Python<'py>, arr: Array<T, D>) -> &'py Self {
         Self::from_owned_array_bound(py, arr).into_gil_ref()
     }
@@ -821,6 +840,10 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     }
 
     /// Deprecated form of [`PyArray<T, D>::from_array_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by PyArray::from_array_bound in the future"
+    )]
     pub fn from_array<'py, S>(py: Python<'py>, arr: &ArrayBase<S, D>) -> &'py Self
     where
         S: Data<Elem = T>,
@@ -981,6 +1004,10 @@ where
 impl<D: Dimension> PyArray<PyObject, D> {
     /// Deprecated form of [`PyArray<T, D>::from_owned_object_array_bound`]
     #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by PyArray::from_owned_object_array_bound in the future"
+    )]
     pub fn from_owned_object_array<'py, T>(py: Python<'py>, arr: Array<Py<T>, D>) -> &'py Self {
         Self::from_owned_object_array_bound(py, arr).into_gil_ref()
     }
@@ -1119,17 +1146,29 @@ impl<T: Element> PyArray<T, Ix1> {
 #[cfg(feature = "gil-refs")]
 impl<T: Element> PyArray<T, Ix1> {
     /// Deprecated form of [`PyArray<T, Ix1>::from_slice_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `PyArray::from_slice_bound` in the future"
+    )]
     pub fn from_slice<'py>(py: Python<'py>, slice: &[T]) -> &'py Self {
         Self::from_slice_bound(py, slice).into_gil_ref()
     }
 
     /// Deprecated form of [`PyArray<T, Ix1>::from_vec_bound`]
     #[inline(always)]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `PyArray::from_vec_bound` in the future"
+    )]
     pub fn from_vec<'py>(py: Python<'py>, vec: Vec<T>) -> &'py Self {
         Self::from_vec_bound(py, vec).into_gil_ref()
     }
 
     /// Deprecated form of [`PyArray<T, Ix1>::from_iter_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by PyArray::from_iter_bound in the future"
+    )]
     pub fn from_iter<'py, I>(py: Python<'py>, iter: I) -> &'py Self
     where
         I: IntoIterator<Item = T>,
@@ -1141,6 +1180,10 @@ impl<T: Element> PyArray<T, Ix1> {
 impl<T: Element> PyArray<T, Ix2> {
     /// Deprecated form of [`PyArray<T, Ix2>::from_vec2_bound`]
     #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `PyArray::from_vec2_bound` in the future"
+    )]
     pub fn from_vec2<'py>(py: Python<'py>, v: &[Vec<T>]) -> Result<&'py Self, FromVecError> {
         Self::from_vec2_bound(py, v).map(Bound::into_gil_ref)
     }
@@ -1191,6 +1234,10 @@ impl<T: Element> PyArray<T, Ix2> {
 impl<T: Element> PyArray<T, Ix3> {
     /// Deprecated form of [`PyArray<T, Ix3>::from_vec3_bound`]
     #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `PyArray::from_vec3_bound` in the future"
+    )]
     pub fn from_vec3<'py>(py: Python<'py>, v: &[Vec<Vec<T>>]) -> Result<&'py Self, FromVecError> {
         Self::from_vec3_bound(py, v).map(Bound::into_gil_ref)
     }
@@ -1428,6 +1475,10 @@ impl<T: Element, D> PyArray<T, D> {
 impl<T: Element + AsPrimitive<f64>> PyArray<T, Ix1> {
     /// Deprecated form of [`PyArray<T, Ix1>::arange_bound`]
     #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by PyArray::arange_bound in the future"
+    )]
     pub fn arange<'py>(py: Python<'py>, start: T, stop: T, step: T) -> &Self {
         Self::arange_bound(py, start, stop, step).into_gil_ref()
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -2271,7 +2271,7 @@ impl<'py, T, D> PyArrayMethods<'py, T, D> for Bound<'py, PyArray<T, D>> {
         as_view(self, |shape, ptr| unsafe {
             RawArrayViewMut::from_shape_ptr(shape, ptr)
         })
-    }    
+    }
 
     fn to_owned_array(&self) -> Array<T, D>
     where

--- a/src/array.rs
+++ b/src/array.rs
@@ -19,9 +19,11 @@ use num_traits::AsPrimitive;
 use pyo3::{
     ffi, pyobject_native_type_base,
     types::{DerefToPyAny, PyAnyMethods, PyModule},
-    AsPyPointer, Bound, DowncastError, FromPyObject, IntoPy, Py, PyAny, PyErr, PyNativeType,
-    PyObject, PyResult, PyTypeInfo, Python,
+    AsPyPointer, Bound, DowncastError, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, PyTypeInfo,
+    Python,
 };
+#[cfg(feature = "gil-refs")]
+use pyo3::{FromPyObject, PyNativeType};
 
 use crate::borrow::{PyReadonlyArray, PyReadwriteArray};
 use crate::cold;
@@ -170,6 +172,7 @@ impl<T, D> IntoPy<Py<PyArray<T, D>>> for &'_ PyArray<T, D> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<T, D> From<&'_ PyArray<T, D>> for Py<PyArray<T, D>> {
     #[inline]
     fn from(other: &PyArray<T, D>) -> Self {
@@ -189,6 +192,7 @@ impl<T, D> IntoPy<PyObject> for PyArray<T, D> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<'py, T: Element, D: Dimension> FromPyObject<'py> for &'py PyArray<T, D> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         PyArray::extract(ob).cloned().map(Bound::into_gil_ref)
@@ -201,7 +205,10 @@ impl<T, D> PyArray<T, D> {
     pub fn as_untyped(&self) -> &PyUntypedArray {
         unsafe { &*(self as *const Self as *const PyUntypedArray) }
     }
+}
 
+#[cfg(feature = "gil-refs")]
+impl<T, D> PyArray<T, D> {
     /// Turn `&PyArray<T,D>` into `Py<PyArray<T,D>>`,
     /// i.e. a pointer into Python's heap which is independent of the GIL lifetime.
     ///
@@ -222,7 +229,6 @@ impl<T, D> PyArray<T, D> {
     ///     assert_eq!(array.bind(py).readonly().as_slice().unwrap(), [0.0; 5]);
     /// });
     /// ```
-    #[deprecated(since = "0.21.0", note = "use Bound::unbind() instead")]
     pub fn to_owned(&self) -> Py<Self> {
         unsafe { Py::from_borrowed_ptr(self.py(), self.as_ptr()) }
     }
@@ -232,7 +238,6 @@ impl<T, D> PyArray<T, D> {
     /// # Safety
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_owned_ptr_or_opt`] and inherits its safety contract.
-    #[deprecated(since = "0.21.0", note = "use Bound::from_owned_ptr() instead")]
     pub unsafe fn from_owned_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
         #[allow(deprecated)]
         py.from_owned_ptr(ptr)
@@ -243,7 +248,6 @@ impl<T, D> PyArray<T, D> {
     /// # Safety
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_borrowed_ptr_or_opt`] and inherits its safety contract.
-    #[deprecated(since = "0.21.0", note = "use Bound::from_borrowed_ptr() instead")]
     pub unsafe fn from_borrowed_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
         #[allow(deprecated)]
         py.from_borrowed_ptr(ptr)
@@ -285,27 +289,6 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         }
 
         Ok(array)
-    }
-
-    /// Same as [`shape`][PyUntypedArray::shape], but returns `D` instead of `&[usize]`.
-    #[inline(always)]
-    pub fn dims(&self) -> D {
-        D::from_dimension(&Dim(self.shape())).expect(DIMENSIONALITY_MISMATCH_ERR)
-    }
-
-    /// Deprecated form of [`PyArray<T, D>::new_bound`]
-    ///
-    /// # Safety
-    /// Same as [`PyArray<T, D>::new_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `PyArray::new_bound` in the future"
-    )]
-    pub unsafe fn new<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &Self
-    where
-        ID: IntoDimension<Dim = D>,
-    {
-        Self::new_bound(py, dims, is_fortran).into_gil_ref()
     }
 
     /// Creates a new uninitialized NumPy array.
@@ -432,24 +415,6 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         Self::new_with_data(py, dims, strides, data_ptr, container.cast())
     }
 
-    /// Deprecated form of [`PyArray<T, D>::borrow_from_array_bound`]
-    ///
-    /// # Safety
-    /// Same as [`PyArray<T, D>::borrow_from_array_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `PyArray::borrow_from_array_bound` in the future"
-    )]
-    pub unsafe fn borrow_from_array<'py, S>(
-        array: &ArrayBase<S, D>,
-        container: &'py PyAny,
-    ) -> &'py Self
-    where
-        S: Data<Elem = T>,
-    {
-        Self::borrow_from_array_bound(array, (*container.as_borrowed()).clone()).into_gil_ref()
-    }
-
     /// Creates a NumPy array backed by `array` and ties its ownership to the Python object `container`.
     ///
     /// # Safety
@@ -501,18 +466,6 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         )
     }
 
-    /// Deprecated form of [`PyArray<T, D>::zeros_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `PyArray::zeros_bound` in the future"
-    )]
-    pub fn zeros<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &Self
-    where
-        ID: IntoDimension<Dim = D>,
-    {
-        Self::zeros_bound(py, dims, is_fortran).into_gil_ref()
-    }
-
     /// Construct a new NumPy array filled with zeros.
     ///
     /// If `is_fortran` is true, then it has Fortran/column-major order,
@@ -555,6 +508,104 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
         }
     }
 
+    /// Constructs a NumPy from an [`ndarray::Array`]
+    ///
+    /// This method uses the internal [`Vec`] of the [`ndarray::Array`] as the base object of the NumPy array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use numpy::{PyArray, PyArrayMethods};
+    /// use ndarray::array;
+    /// use pyo3::Python;
+    ///
+    /// Python::with_gil(|py| {
+    ///     let pyarray = PyArray::from_owned_array_bound(py, array![[1, 2], [3, 4]]);
+    ///
+    ///     assert_eq!(pyarray.readonly().as_array(), array![[1, 2], [3, 4]]);
+    /// });
+    /// ```
+    pub fn from_owned_array_bound(py: Python<'_>, mut arr: Array<T, D>) -> Bound<'_, Self> {
+        let (strides, dims) = (arr.npy_strides(), arr.raw_dim());
+        let data_ptr = arr.as_mut_ptr();
+        unsafe {
+            Self::from_raw_parts(
+                py,
+                dims,
+                strides.as_ptr(),
+                data_ptr,
+                PySliceContainer::from(arr),
+            )
+        }
+    }
+
+    /// Construct a NumPy array from a [`ndarray::ArrayBase`].
+    ///
+    /// This method allocates memory in Python's heap via the NumPy API,
+    /// and then copies all elements of the array there.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use numpy::{PyArray, PyArrayMethods};
+    /// use ndarray::array;
+    /// use pyo3::Python;
+    ///
+    /// Python::with_gil(|py| {
+    ///     let pyarray = PyArray::from_array_bound(py, &array![[1, 2], [3, 4]]);
+    ///
+    ///     assert_eq!(pyarray.readonly().as_array(), array![[1, 2], [3, 4]]);
+    /// });
+    /// ```
+    pub fn from_array_bound<'py, S>(py: Python<'py>, arr: &ArrayBase<S, D>) -> Bound<'py, Self>
+    where
+        S: Data<Elem = T>,
+    {
+        ToPyArray::to_pyarray_bound(arr, py)
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl<T: Element, D: Dimension> PyArray<T, D> {
+    /// Same as [`shape`][PyUntypedArray::shape], but returns `D` instead of `&[usize]`.
+    #[inline(always)]
+    pub fn dims(&self) -> D {
+        D::from_dimension(&Dim(self.shape())).expect(DIMENSIONALITY_MISMATCH_ERR)
+    }
+
+    /// Deprecated form of [`PyArray<T, D>::new_bound`]
+    ///
+    /// # Safety
+    /// Same as [`PyArray<T, D>::new_bound`]
+    pub unsafe fn new<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &Self
+    where
+        ID: IntoDimension<Dim = D>,
+    {
+        Self::new_bound(py, dims, is_fortran).into_gil_ref()
+    }
+
+    /// Deprecated form of [`PyArray<T, D>::borrow_from_array_bound`]
+    ///
+    /// # Safety
+    /// Same as [`PyArray<T, D>::borrow_from_array_bound`]
+    pub unsafe fn borrow_from_array<'py, S>(
+        array: &ArrayBase<S, D>,
+        container: &'py PyAny,
+    ) -> &'py Self
+    where
+        S: Data<Elem = T>,
+    {
+        Self::borrow_from_array_bound(array, (*container.as_borrowed()).clone()).into_gil_ref()
+    }
+
+    /// Deprecated form of [`PyArray<T, D>::zeros_bound`]
+    pub fn zeros<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &Self
+    where
+        ID: IntoDimension<Dim = D>,
+    {
+        Self::zeros_bound(py, dims, is_fortran).into_gil_ref()
+    }
+
     /// Returns an immutable view of the internal data as a slice.
     ///
     /// # Safety
@@ -590,43 +641,8 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     }
 
     /// Deprecated form of [`PyArray<T, D>::from_owned_array_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by PyArray::from_owned_array_bound in the future"
-    )]
     pub fn from_owned_array<'py>(py: Python<'py>, arr: Array<T, D>) -> &'py Self {
         Self::from_owned_array_bound(py, arr).into_gil_ref()
-    }
-
-    /// Constructs a NumPy from an [`ndarray::Array`]
-    ///
-    /// This method uses the internal [`Vec`] of the [`ndarray::Array`] as the base object of the NumPy array.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use numpy::{PyArray, PyArrayMethods};
-    /// use ndarray::array;
-    /// use pyo3::Python;
-    ///
-    /// Python::with_gil(|py| {
-    ///     let pyarray = PyArray::from_owned_array_bound(py, array![[1, 2], [3, 4]]);
-    ///
-    ///     assert_eq!(pyarray.readonly().as_array(), array![[1, 2], [3, 4]]);
-    /// });
-    /// ```
-    pub fn from_owned_array_bound(py: Python<'_>, mut arr: Array<T, D>) -> Bound<'_, Self> {
-        let (strides, dims) = (arr.npy_strides(), arr.raw_dim());
-        let data_ptr = arr.as_mut_ptr();
-        unsafe {
-            Self::from_raw_parts(
-                py,
-                dims,
-                strides.as_ptr(),
-                data_ptr,
-                PySliceContainer::from(arr),
-            )
-        }
     }
 
     /// Get a reference of the specified element if the given index is valid.
@@ -805,40 +821,11 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
     }
 
     /// Deprecated form of [`PyArray<T, D>::from_array_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by PyArray::from_array_bound in the future"
-    )]
     pub fn from_array<'py, S>(py: Python<'py>, arr: &ArrayBase<S, D>) -> &'py Self
     where
         S: Data<Elem = T>,
     {
         Self::from_array_bound(py, arr).into_gil_ref()
-    }
-
-    /// Construct a NumPy array from a [`ndarray::ArrayBase`].
-    ///
-    /// This method allocates memory in Python's heap via the NumPy API,
-    /// and then copies all elements of the array there.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use numpy::{PyArray, PyArrayMethods};
-    /// use ndarray::array;
-    /// use pyo3::Python;
-    ///
-    /// Python::with_gil(|py| {
-    ///     let pyarray = PyArray::from_array_bound(py, &array![[1, 2], [3, 4]]);
-    ///
-    ///     assert_eq!(pyarray.readonly().as_array(), array![[1, 2], [3, 4]]);
-    /// });
-    /// ```
-    pub fn from_array_bound<'py, S>(py: Python<'py>, arr: &ArrayBase<S, D>) -> Bound<'py, Self>
-    where
-        S: Data<Elem = T>,
-    {
-        ToPyArray::to_pyarray_bound(arr, py)
     }
 
     /// Get an immutable borrow of the NumPy array
@@ -992,10 +979,7 @@ where
 
 impl<D: Dimension> PyArray<PyObject, D> {
     /// Deprecated form of [`PyArray<T, D>::from_owned_object_array_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by PyArray::from_owned_object_array_bound in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     pub fn from_owned_object_array<'py, T>(py: Python<'py>, arr: Array<Py<T>, D>) -> &'py Self {
         Self::from_owned_object_array_bound(py, arr).into_gil_ref()
     }
@@ -1053,6 +1037,7 @@ impl<D: Dimension> PyArray<PyObject, D> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<T: Copy + Element> PyArray<T, Ix0> {
     /// Get the single element of a zero-dimensional array.
     ///
@@ -1063,15 +1048,6 @@ impl<T: Copy + Element> PyArray<T, Ix0> {
 }
 
 impl<T: Element> PyArray<T, Ix1> {
-    /// Deprecated form of [`PyArray<T, Ix1>::from_slice_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `PyArray::from_slice_bound` in the future"
-    )]
-    pub fn from_slice<'py>(py: Python<'py>, slice: &[T]) -> &'py Self {
-        Self::from_slice_bound(py, slice).into_gil_ref()
-    }
-
     /// Construct a one-dimensional array from a [mod@slice].
     ///
     /// # Example
@@ -1095,16 +1071,6 @@ impl<T: Element> PyArray<T, Ix1> {
         }
     }
 
-    /// Deprecated form of [`PyArray<T, Ix1>::from_vec_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `PyArray::from_vec_bound` in the future"
-    )]
-    #[inline(always)]
-    pub fn from_vec<'py>(py: Python<'py>, vec: Vec<T>) -> &'py Self {
-        Self::from_vec_bound(py, vec).into_gil_ref()
-    }
-
     /// Construct a one-dimensional array from a [`Vec<T>`][Vec].
     ///
     /// # Example
@@ -1122,18 +1088,6 @@ impl<T: Element> PyArray<T, Ix1> {
     #[inline(always)]
     pub fn from_vec_bound<'py>(py: Python<'py>, vec: Vec<T>) -> Bound<'py, Self> {
         vec.into_pyarray_bound(py)
-    }
-
-    /// Deprecated form of [`PyArray<T, Ix1>::from_iter_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by PyArray::from_iter_bound in the future"
-    )]
-    pub fn from_iter<'py, I>(py: Python<'py>, iter: I) -> &'py Self
-    where
-        I: IntoIterator<Item = T>,
-    {
-        Self::from_iter_bound(py, iter).into_gil_ref()
     }
 
     /// Construct a one-dimensional array from an [`Iterator`].
@@ -1161,12 +1115,31 @@ impl<T: Element> PyArray<T, Ix1> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
+impl<T: Element> PyArray<T, Ix1> {
+    /// Deprecated form of [`PyArray<T, Ix1>::from_slice_bound`]
+    pub fn from_slice<'py>(py: Python<'py>, slice: &[T]) -> &'py Self {
+        Self::from_slice_bound(py, slice).into_gil_ref()
+    }
+
+    /// Deprecated form of [`PyArray<T, Ix1>::from_vec_bound`]
+    #[inline(always)]
+    pub fn from_vec<'py>(py: Python<'py>, vec: Vec<T>) -> &'py Self {
+        Self::from_vec_bound(py, vec).into_gil_ref()
+    }
+
+    /// Deprecated form of [`PyArray<T, Ix1>::from_iter_bound`]
+    pub fn from_iter<'py, I>(py: Python<'py>, iter: I) -> &'py Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self::from_iter_bound(py, iter).into_gil_ref()
+    }
+}
+
 impl<T: Element> PyArray<T, Ix2> {
     /// Deprecated form of [`PyArray<T, Ix2>::from_vec2_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `PyArray::from_vec2_bound` in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     pub fn from_vec2<'py>(py: Python<'py>, v: &[Vec<T>]) -> Result<&'py Self, FromVecError> {
         Self::from_vec2_bound(py, v).map(Bound::into_gil_ref)
     }
@@ -1216,10 +1189,7 @@ impl<T: Element> PyArray<T, Ix2> {
 
 impl<T: Element> PyArray<T, Ix3> {
     /// Deprecated form of [`PyArray<T, Ix3>::from_vec3_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `PyArray::from_vec3_bound` in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     pub fn from_vec3<'py>(py: Python<'py>, v: &[Vec<Vec<T>>]) -> Result<&'py Self, FromVecError> {
         Self::from_vec3_bound(py, v).map(Bound::into_gil_ref)
     }
@@ -1283,6 +1253,7 @@ impl<T: Element> PyArray<T, Ix3> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<T: Element, D> PyArray<T, D> {
     /// Copies `self` into `other`, performing a data type conversion if necessary.
     ///
@@ -1455,10 +1426,7 @@ impl<T: Element, D> PyArray<T, D> {
 
 impl<T: Element + AsPrimitive<f64>> PyArray<T, Ix1> {
     /// Deprecated form of [`PyArray<T, Ix1>::arange_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by PyArray::arange_bound in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     pub fn arange<'py>(py: Python<'py>, start: T, stop: T, step: T) -> &Self {
         Self::arange_bound(py, start, stop, step).into_gil_ref()
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -239,7 +239,7 @@ impl<T, D> PyArray<T, D> {
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_owned_ptr_or_opt`] and inherits its safety contract.
     pub unsafe fn from_owned_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
-        #[allow(deprecated)]
+        #![allow(deprecated)]
         py.from_owned_ptr(ptr)
     }
 
@@ -249,7 +249,7 @@ impl<T, D> PyArray<T, D> {
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_borrowed_ptr_or_opt`] and inherits its safety contract.
     pub unsafe fn from_borrowed_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
-        #[allow(deprecated)]
+        #![allow(deprecated)]
         py.from_borrowed_ptr(ptr)
     }
 

--- a/src/borrow/mod.rs
+++ b/src/borrow/mod.rs
@@ -305,7 +305,7 @@ where
     /// }
     ///
     /// Python::with_gil(|py| {
-    ///     let np = py.eval("__import__('numpy')", None, None).unwrap();
+    ///     let np = py.eval_bound("__import__('numpy')", None, None).unwrap();
     ///     let sum_standard_layout = wrap_pyfunction!(sum_standard_layout)(py).unwrap();
     ///     let sum_dynamic_strides = wrap_pyfunction!(sum_dynamic_strides)(py).unwrap();
     ///

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -195,7 +195,7 @@ where
                     let array = PyArray::<A, _>::new_bound(py, dim, false);
                     let mut data_ptr = array.data();
                     for item in self.iter() {
-                        data_ptr.write(item.clone());
+                        data_ptr.write(item.py_clone(py));
                         data_ptr = data_ptr.add(1);
                     }
                     array
@@ -228,7 +228,7 @@ where
                 ptr::copy_nonoverlapping(self.data.ptr(), data_ptr, self.len());
             } else {
                 for item in self.iter() {
-                    data_ptr.write(item.clone());
+                    data_ptr.write(item.py_clone(py));
                     data_ptr = data_ptr.add(1);
                 }
             }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -41,6 +41,10 @@ pub trait IntoPyArray: Sized {
     type Dim: Dimension;
 
     /// Deprecated form of [`IntoPyArray::into_pyarray_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `IntoPyArray::into_pyarray_bound` in the future"
+    )]
     #[cfg(feature = "gil-refs")]
     fn into_pyarray<'py>(self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         Self::into_pyarray_bound(self, py).into_gil_ref()
@@ -149,6 +153,10 @@ pub trait ToPyArray {
     type Dim: Dimension;
 
     /// Deprecated form of [`ToPyArray::to_pyarray_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "will be replaced by `ToPyArray::to_pyarray_bound` in the future"
+    )]
     #[cfg(feature = "gil-refs")]
     fn to_pyarray<'py>(&self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         Self::to_pyarray_bound(self, py).into_gil_ref()

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -203,7 +203,7 @@ where
                     let array = PyArray::<A, _>::new_bound(py, dim, false);
                     let mut data_ptr = array.data();
                     for item in self.iter() {
-                        data_ptr.write(item.py_clone(py));
+                        data_ptr.write(item.clone_ref(py));
                         data_ptr = data_ptr.add(1);
                     }
                     array
@@ -236,7 +236,7 @@ where
                 ptr::copy_nonoverlapping(self.data.ptr(), data_ptr, self.len());
             } else {
                 for item in self.iter() {
-                    data_ptr.write(item.py_clone(py));
+                    data_ptr.write(item.clone_ref(py));
                     data_ptr = data_ptr.add(1);
                 }
             }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -41,10 +41,7 @@ pub trait IntoPyArray: Sized {
     type Dim: Dimension;
 
     /// Deprecated form of [`IntoPyArray::into_pyarray_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `IntoPyArray::into_pyarray_bound` in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     fn into_pyarray<'py>(self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         Self::into_pyarray_bound(self, py).into_gil_ref()
     }
@@ -152,10 +149,7 @@ pub trait ToPyArray {
     type Dim: Dimension;
 
     /// Deprecated form of [`ToPyArray::to_pyarray_bound`]
-    #[deprecated(
-        since = "0.21.0",
-        note = "will be replaced by `ToPyArray::to_pyarray_bound` in the future"
-    )]
+    #[cfg(feature = "gil-refs")]
     fn to_pyarray<'py>(&self, py: Python<'py>) -> &'py PyArray<Self::Item, Self::Dim> {
         Self::to_pyarray_bound(self, py).into_gil_ref()
     }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -243,7 +243,7 @@ impl TypeDescriptors {
             }
         };
 
-        dtype.clone().into_bound(py)
+        dtype.bind(py).to_owned()
     }
 }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -66,7 +66,7 @@ use std::marker::PhantomData;
 use pyo3::{sync::GILProtected, Bound, Py, Python};
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods};
+use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, impl_py_clone};
 use crate::npyffi::{
     PyArray_DatetimeDTypeMetaData, PyDataType_C_METADATA, NPY_DATETIMEUNIT, NPY_TYPES,
 };
@@ -155,6 +155,8 @@ impl<U: Unit> From<Datetime<U>> for i64 {
     }
 }
 
+impl_py_clone!(Datetime<U>; [U: Unit]);
+
 unsafe impl<U: Unit> Element for Datetime<U> {
     const IS_COPY: bool = true;
 
@@ -189,6 +191,8 @@ impl<U: Unit> From<Timedelta<U>> for i64 {
         val.0
     }
 }
+
+impl_py_clone!(Timedelta<U>; [U: Unit]);
 
 unsafe impl<U: Unit> Element for Timedelta<U> {
     const IS_COPY: bool = true;

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -66,7 +66,7 @@ use std::marker::PhantomData;
 use pyo3::{sync::GILProtected, Bound, Py, Python};
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, clone_methods_impl};
+use crate::dtype::{clone_methods_impl, Element, PyArrayDescr, PyArrayDescrMethods};
 use crate::npyffi::{
     PyArray_DatetimeDTypeMetaData, PyDataType_C_METADATA, NPY_DATETIMEUNIT, NPY_TYPES,
 };

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -66,7 +66,7 @@ use std::marker::PhantomData;
 use pyo3::{sync::GILProtected, Bound, Py, Python};
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, impl_py_clone};
+use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, clone_methods_impl};
 use crate::npyffi::{
     PyArray_DatetimeDTypeMetaData, PyDataType_C_METADATA, NPY_DATETIMEUNIT, NPY_TYPES,
 };
@@ -155,8 +155,6 @@ impl<U: Unit> From<Datetime<U>> for i64 {
     }
 }
 
-impl_py_clone!(Datetime<U>; [U: Unit]);
-
 unsafe impl<U: Unit> Element for Datetime<U> {
     const IS_COPY: bool = true;
 
@@ -165,6 +163,8 @@ unsafe impl<U: Unit> Element for Datetime<U> {
 
         DTYPES.from_unit(py, U::UNIT)
     }
+
+    clone_methods_impl!(Self);
 }
 
 impl<U: Unit> fmt::Debug for Datetime<U> {
@@ -192,8 +192,6 @@ impl<U: Unit> From<Timedelta<U>> for i64 {
     }
 }
 
-impl_py_clone!(Timedelta<U>; [U: Unit]);
-
 unsafe impl<U: Unit> Element for Timedelta<U> {
     const IS_COPY: bool = true;
 
@@ -202,6 +200,8 @@ unsafe impl<U: Unit> Element for Timedelta<U> {
 
         DTYPES.from_unit(py, U::UNIT)
     }
+
+    clone_methods_impl!(Self);
 }
 
 impl<U: Unit> fmt::Debug for Timedelta<U> {

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -825,6 +825,7 @@ mod tests {
     use super::*;
 
     use pyo3::{py_run, types::PyTypeMethods};
+    use pyo3::types::PyString;
 
     use crate::npyffi::{is_numpy_2, NPY_NEEDS_PYAPI};
 
@@ -851,7 +852,7 @@ mod tests {
 
     #[test]
     fn test_dtype_names() {
-        fn type_name<'py, T: Element>(py: Python<'py>) -> String {
+        fn type_name<T: Element>(py: Python) -> Bound<PyString> {
             dtype_bound::<T>(py).typeobj().qualname().unwrap()
         }
         Python::with_gil(|py| {

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -5,6 +5,8 @@ use std::ptr;
 #[cfg(feature = "half")]
 use half::{bf16, f16};
 use num_traits::{Bounded, Zero};
+#[cfg(feature = "half")]
+use pyo3::sync::GILOnceCell;
 use pyo3::{
     exceptions::{PyIndexError, PyValueError},
     ffi::{self, PyTuple_Size},
@@ -12,8 +14,6 @@ use pyo3::{
     types::{PyAnyMethods, PyDict, PyDictMethods, PyTuple, PyType},
     Borrowed, Bound, Py, PyAny, PyObject, PyResult, PyTypeInfo, Python, ToPyObject,
 };
-#[cfg(feature = "half")]
-use pyo3::{sync::GILOnceCell};
 #[cfg(feature = "gil-refs")]
 use pyo3::{AsPyPointer, PyNativeType};
 
@@ -790,14 +790,14 @@ macro_rules! clone_methods_impl {
         #[inline]
         fn array_from_view<D>(
             _py: ::pyo3::Python<'_>,
-            view: ::ndarray::ArrayView<'_, $Self, D>
+            view: ::ndarray::ArrayView<'_, $Self, D>,
         ) -> ::ndarray::Array<$Self, D>
         where
-            D: ::ndarray::Dimension
+            D: ::ndarray::Dimension,
         {
             ::ndarray::ArrayView::to_owned(&view)
         }
-    }
+    };
 }
 pub(crate) use clone_methods_impl;
 

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -71,6 +71,10 @@ pyobject_native_type_extract!(PyArrayDescr);
 
 /// Returns the type descriptor ("dtype") for a registered type.
 #[cfg(feature = "gil-refs")]
+#[deprecated(
+    since = "0.21.0",
+    note = "This will be replaced by `dtype_bound` in the future."
+)]
 pub fn dtype<'py, T: Element>(py: Python<'py>) -> &'py PyArrayDescr {
     T::get_dtype_bound(py).into_gil_ref()
 }
@@ -136,6 +140,10 @@ impl PyArrayDescr {
     /// Equivalent to invoking the constructor of [`numpy.dtype`][dtype].
     ///
     /// [dtype]: https://numpy.org/doc/stable/reference/generated/numpy.dtype.html
+    #[deprecated(
+        since = "0.21.0",
+        note = "This will be replace by `new_bound` in the future."
+    )]
     pub fn new<'py, T: ToPyObject + ?Sized>(py: Python<'py>, ob: &T) -> PyResult<&'py Self> {
         Self::new_bound(py, ob).map(Bound::into_gil_ref)
     }
@@ -153,11 +161,19 @@ impl PyArrayDescr {
     }
 
     /// Shortcut for creating a type descriptor of `object` type.
+    #[deprecated(
+        since = "0.21.0",
+        note = "This will be replaced by `object_bound` in the future."
+    )]
     pub fn object<'py>(py: Python<'py>) -> &'py Self {
         Self::object_bound(py).into_gil_ref()
     }
 
     /// Returns the type descriptor for a registered type.
+    #[deprecated(
+        since = "0.21.0",
+        note = "This will be replaced by `of_bound` in the future."
+    )]
     pub fn of<'py, T: Element>(py: Python<'py>) -> &'py Self {
         Self::of_bound::<T>(py).into_gil_ref()
     }
@@ -693,6 +709,10 @@ pub unsafe trait Element: Sized + Send {
 
     /// Returns the associated type descriptor ("dtype") for the given element type.
     #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "This will be replaced by `get_dtype_bound` in the future."
+    )]
     fn get_dtype<'py>(py: Python<'py>) -> &'py PyArrayDescr {
         Self::get_dtype_bound(py).into_gil_ref()
     }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -1,7 +1,6 @@
 use std::mem::size_of;
 use std::os::raw::{c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort};
 use std::ptr;
-use ndarray::{Array, ArrayView, Dimension};
 
 #[cfg(feature = "half")]
 use half::{bf16, f16};
@@ -645,54 +644,55 @@ impl<'py> PyArrayDescrMethods<'py> for Bound<'py, PyArrayDescr> {
 
 impl Sealed for Bound<'_, PyArrayDescr> {}
 
-
 /// Weaker form of `Clone` for types that can be cloned while the GIL is held.
-/// 
-/// Any type that implements `Clone` can trivially implement `PyClone` by forwarding 
-/// to the `Clone::clone` method. However, some types (notably `PyObject`) can only 
+///
+/// Any type that implements `Clone` can trivially implement `PyClone` by forwarding
+/// to the `Clone::clone` method. However, some types (notably `PyObject`) can only
 /// be safely cloned while the GIL is held, and therefore cannot implement `Clone`.
 /// This trait provides a mechanism for performing a clone while the GIL is held, as
 /// represented by the [`Python`] token provided as an argument to the [`py_clone`]
-/// method. All API's in the `numpy` crate require the GIL to be held, so this weaker 
+/// method. All API's in the `numpy` crate require the GIL to be held, so this weaker
 /// alternative to `Clone` is a sufficient prerequisite for implementing the
 /// [`Element`] trait.
-/// 
+///
 /// # Implementing `PyClone`
 /// Implementing this trait is trivial for most types, and simply requires defining
-/// the `py_clone` method. The `vec_from_slice` and `array_from_view` methods have 
-/// default implementations that simply map the `py_clone` method to each item in 
+/// the `py_clone` method. The `vec_from_slice` and `array_from_view` methods have
+/// default implementations that simply map the `py_clone` method to each item in
 /// the collection, but types may want to override these implementations if there
-/// is a more efficient way to perform the conversion. In particular, `Clone` types 
-/// may instead defer to the `ToOwned::to_owned` and `ArrayBase::to_owned` methods 
+/// is a more efficient way to perform the conversion. In particular, `Clone` types
+/// may instead defer to the `ToOwned::to_owned` and `ArrayBase::to_owned` methods
 /// for increased performance.
-/// 
+///
 /// [`py_clone`]: Self::py_clone
 pub trait PyClone: Sized {
     /// Create a clone of the value while the GIL is guaranteed to be held.
     fn py_clone(&self, py: Python<'_>) -> Self;
-    
+
     /// Create an owned copy of the slice while the GIL is guaranteed to be held.
-    /// 
-    /// Some types may provide implementations of this method that are more efficient 
+    ///
+    /// Some types may provide implementations of this method that are more efficient
     /// than simply mapping the `py_clone` method to each element in the slice.
     #[inline]
     fn vec_from_slice(py: Python<'_>, slc: &[Self]) -> Vec<Self> {
         slc.iter().map(|elem| elem.py_clone(py)).collect()
     }
-    
+
     /// Create an owned copy of the array while the GIL is guaranteed to be held.
-    /// 
-    /// Some types may provide implementations of this method that are more efficient 
+    ///
+    /// Some types may provide implementations of this method that are more efficient
     /// than simply mapping the `py_clone` method to each element in the view.
     #[inline]
-    fn array_from_view<D>(py: Python<'_>, view: ArrayView<'_, Self, D>) -> Array<Self, D> 
+    fn array_from_view<D>(
+        py: Python<'_>,
+        view: ::ndarray::ArrayView<'_, Self, D>,
+    ) -> ::ndarray::Array<Self, D>
     where
-        D: Dimension
+        D: ::ndarray::Dimension,
     {
         view.map(|elem| elem.py_clone(py))
     }
 }
-
 
 /// Represents that a type can be an element of `PyArray`.
 ///
@@ -804,17 +804,17 @@ macro_rules! impl_py_clone {
             fn py_clone(&self, _py: ::pyo3::Python<'_>) -> Self {
                 self.clone()
             }
-            
+
             #[inline]
             fn vec_from_slice(_py: ::pyo3::Python<'_>, slc: &[Self]) -> Vec<Self> {
                 slc.to_owned()
             }
-            
+
             #[inline]
             fn array_from_view<D>(
-                _py: ::pyo3::Python<'_>, 
+                _py: ::pyo3::Python<'_>,
                 view: ::ndarray::ArrayView<'_, Self, D>
-            ) -> ::ndarray::Array<Self, D> 
+            ) -> ::ndarray::Array<Self, D>
             where
                 D: ::ndarray::Dimension
             {
@@ -930,7 +930,7 @@ mod tests {
 
     #[test]
     fn test_dtype_names() {
-        fn type_name<T: Element>(py: Python) -> Bound<PyString> {
+        fn type_name<T: Element>(py: Python<'_>) -> Bound<'_, PyString> {
             dtype_bound::<T>(py).typeobj().qualname().unwrap()
         }
         Python::with_gil(|py| {

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -867,7 +867,7 @@ unsafe impl Element for bf16 {
             .get_or_init(py, || {
                 PyArrayDescr::new_bound(py, "bfloat16").expect("A package which provides a `bfloat16` data type for NumPy is required to use the `half::bf16` element type.").unbind()
             })
-            .clone()
+            .clone_ref(py)
             .into_bound(py)
     }
 }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -883,6 +883,13 @@ impl_element_scalar!(Complex64 => NPY_CDOUBLE,
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl_element_scalar!(usize, isize);
 
+impl PyClone for PyObject {
+    #[inline]
+    fn py_clone(&self, py: Python<'_>) -> Self {
+        self.clone_ref(py)
+    }
+}
+
 unsafe impl Element for PyObject {
     const IS_COPY: bool = false;
 

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -731,7 +731,7 @@ pub trait PyClone: Sized {
 ///
 /// [enumerated-types]: https://numpy.org/doc/stable/reference/c-api/dtype.html#enumerated-types
 /// [data-models]: https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
-pub unsafe trait Element: Clone + Send {
+pub unsafe trait Element: PyClone + Send {
     /// Flag that indicates whether this type is trivially copyable.
     ///
     /// It should be set to true for all trivially copyable types (like scalar types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,10 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 #![cfg_attr(not(feature = "nalgebra"), doc = "```rust,ignore")]
 //! use numpy::pyo3::Python;
 //! use numpy::nalgebra::Matrix3;
-//! use numpy::{pyarray, ToPyArray};
+//! use numpy::{pyarray_bound, ToPyArray, PyArrayMethods};
 //!
 //! Python::with_gil(|py| {
-//!     let py_array = pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+//!     let py_array = pyarray_bound![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
 //!
 //!     let py_array_square;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //!         Matrix3::new(30, 36, 42, 66, 81, 96, 102, 126, 150)
 //!     );
 //! });
-//! ```
+#![doc = "```"]
 //!
 //! [c-api]: https://numpy.org/doc/stable/reference/c-api
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,11 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //!
 //! [c-api]: https://numpy.org/doc/stable/reference/c-api
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html
-
-#![deny(missing_docs, missing_debug_implementations)]
+#![deny(missing_docs)]
+// requiring `Debug` impls is not relevant without gil-refs since `&PyArray` and 
+// similar aren't constructible and the `pyo3::pyobject_native_type_base` macro 
+// does not provide a `Debug` impl
+#![cfg_attr(feature = "gil-refs", deny(missing_debug_implementations))]
 
 #[cfg(all(target_os = "windows", target_arch = "x86"))]
 compile_error!("Compilation for 32-bit windows is not currently supported. See https://github.com/PyO3/rust-numpy/issues/448");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub use crate::borrow::{
     PyReadwriteArray5, PyReadwriteArray6, PyReadwriteArrayDyn,
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-#[allow(deprecated)]
+#[cfg(feature = "gil-refs")]
 pub use crate::dtype::dtype;
 pub use crate::dtype::{
     dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub use crate::borrow::{
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 #[cfg(feature = "gil-refs")]
+#[allow(deprecated)]
 pub use crate::dtype::dtype;
 pub use crate::dtype::{
     dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods,
@@ -120,6 +121,7 @@ pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::strings::{PyFixedString, PyFixedUnicode};
 #[cfg(feature = "gil-refs")]
+#[allow(deprecated)]
 pub use crate::sum_products::{dot, einsum, inner};
 pub use crate::sum_products::{dot_bound, einsum_bound, inner_bound};
 pub use crate::untyped_array::{PyUntypedArray, PyUntypedArrayMethods};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,8 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //! [c-api]: https://numpy.org/doc/stable/reference/c-api
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html
 #![deny(missing_docs)]
-// requiring `Debug` impls is not relevant without gil-refs since `&PyArray` and 
-// similar aren't constructible and the `pyo3::pyobject_native_type_base` macro 
-// does not provide a `Debug` impl
+// requiring `Debug` impls is not relevant without gil-refs since `&PyArray`
+// and similar aren't constructible
 #![cfg_attr(feature = "gil-refs", deny(missing_debug_implementations))]
 
 #[cfg(all(target_os = "windows", target_arch = "x86"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub use crate::dtype::{
 pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::strings::{PyFixedString, PyFixedUnicode};
-#[allow(deprecated)]
+#[cfg(feature = "gil-refs")]
 pub use crate::sum_products::{dot, einsum, inner};
 pub use crate::sum_products::{dot_bound, einsum_bound, inner_bound};
 pub use crate::untyped_array::{PyUntypedArray, PyUntypedArrayMethods};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 #[cfg(feature = "gil-refs")]
 pub use crate::dtype::dtype;
 pub use crate::dtype::{
-    dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods,
+    dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods, PyClone,
 };
 pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 #[cfg(feature = "gil-refs")]
 pub use crate::dtype::dtype;
 pub use crate::dtype::{
-    dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods, PyClone,
+    dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods,
 };
 pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -191,7 +191,7 @@ impl TypeDescriptors {
             }
         };
 
-        dtype.clone().into_bound(py)
+        dtype.bind(py).to_owned()
     }
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -87,7 +87,7 @@ unsafe impl<const N: usize> Element for PyFixedString<N> {
 impl<const N: usize> PyClone for PyFixedString<N> {
     #[inline]
     fn py_clone(&self, _py: Python<'_>) -> Self {
-        self.clone()
+        *self
     }
 
     #[inline]
@@ -98,10 +98,10 @@ impl<const N: usize> PyClone for PyFixedString<N> {
     #[inline]
     fn array_from_view<D>(
         _py: Python<'_>,
-        view: ::ndarray::ArrayView<'_, Self, D>
+        view: ::ndarray::ArrayView<'_, Self, D>,
     ) -> ::ndarray::Array<Self, D>
     where
-        D: ::ndarray::Dimension
+        D: ::ndarray::Dimension,
     {
         view.to_owned()
     }
@@ -171,7 +171,7 @@ impl<const N: usize> From<[Py_UCS4; N]> for PyFixedUnicode<N> {
 impl<const N: usize> PyClone for PyFixedUnicode<N> {
     #[inline]
     fn py_clone(&self, _py: Python<'_>) -> Self {
-        self.clone()
+        *self
     }
 
     #[inline]
@@ -182,10 +182,10 @@ impl<const N: usize> PyClone for PyFixedUnicode<N> {
     #[inline]
     fn array_from_view<D>(
         _py: Python<'_>,
-        view: ::ndarray::ArrayView<'_, Self, D>
+        view: ::ndarray::ArrayView<'_, Self, D>,
     ) -> ::ndarray::Array<Self, D>
     where
-        D: ::ndarray::Dimension
+        D: ::ndarray::Dimension,
     {
         view.to_owned()
     }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -17,7 +17,7 @@ use pyo3::{
 };
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods};
+use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, PyClone};
 use crate::npyffi::PyDataType_SET_ELSIZE;
 use crate::npyffi::NPY_TYPES;
 
@@ -84,6 +84,29 @@ unsafe impl<const N: usize> Element for PyFixedString<N> {
     }
 }
 
+impl<const N: usize> PyClone for PyFixedString<N> {
+    #[inline]
+    fn py_clone(&self, _py: Python<'_>) -> Self {
+        self.clone()
+    }
+
+    #[inline]
+    fn vec_from_slice(_py: Python<'_>, slc: &[Self]) -> Vec<Self> {
+        slc.to_owned()
+    }
+
+    #[inline]
+    fn array_from_view<D>(
+        _py: Python<'_>,
+        view: ::ndarray::ArrayView<'_, Self, D>
+    ) -> ::ndarray::Array<Self, D>
+    where
+        D: ::ndarray::Dimension
+    {
+        view.to_owned()
+    }
+}
+
 /// A newtype wrapper around [`[PyUCS4; N]`][Py_UCS4] to handle [`str_` scalars][numpy-str] while satisfying coherence.
 ///
 /// Note that when creating arrays of Unicode strings without an explicit `dtype`,
@@ -142,6 +165,29 @@ impl<const N: usize> fmt::Display for PyFixedUnicode<N> {
 impl<const N: usize> From<[Py_UCS4; N]> for PyFixedUnicode<N> {
     fn from(val: [Py_UCS4; N]) -> Self {
         Self(val)
+    }
+}
+
+impl<const N: usize> PyClone for PyFixedUnicode<N> {
+    #[inline]
+    fn py_clone(&self, _py: Python<'_>) -> Self {
+        self.clone()
+    }
+
+    #[inline]
+    fn vec_from_slice(_py: Python<'_>, slc: &[Self]) -> Vec<Self> {
+        slc.to_owned()
+    }
+
+    #[inline]
+    fn array_from_view<D>(
+        _py: Python<'_>,
+        view: ::ndarray::ArrayView<'_, Self, D>
+    ) -> ::ndarray::Array<Self, D>
+    where
+        D: ::ndarray::Dimension
+    {
+        view.to_owned()
     }
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -17,7 +17,7 @@ use pyo3::{
 };
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, PyClone};
+use crate::dtype::{clone_methods_impl, Element, PyArrayDescr, PyArrayDescrMethods};
 use crate::npyffi::PyDataType_SET_ELSIZE;
 use crate::npyffi::NPY_TYPES;
 
@@ -82,29 +82,8 @@ unsafe impl<const N: usize> Element for PyFixedString<N> {
 
         unsafe { DTYPES.from_size(py, NPY_TYPES::NPY_STRING, b'|' as _, size_of::<Self>()) }
     }
-}
 
-impl<const N: usize> PyClone for PyFixedString<N> {
-    #[inline]
-    fn py_clone(&self, _py: Python<'_>) -> Self {
-        *self
-    }
-
-    #[inline]
-    fn vec_from_slice(_py: Python<'_>, slc: &[Self]) -> Vec<Self> {
-        slc.to_owned()
-    }
-
-    #[inline]
-    fn array_from_view<D>(
-        _py: Python<'_>,
-        view: ::ndarray::ArrayView<'_, Self, D>,
-    ) -> ::ndarray::Array<Self, D>
-    where
-        D: ::ndarray::Dimension,
-    {
-        view.to_owned()
-    }
+    clone_methods_impl!(Self);
 }
 
 /// A newtype wrapper around [`[PyUCS4; N]`][Py_UCS4] to handle [`str_` scalars][numpy-str] while satisfying coherence.
@@ -168,29 +147,6 @@ impl<const N: usize> From<[Py_UCS4; N]> for PyFixedUnicode<N> {
     }
 }
 
-impl<const N: usize> PyClone for PyFixedUnicode<N> {
-    #[inline]
-    fn py_clone(&self, _py: Python<'_>) -> Self {
-        *self
-    }
-
-    #[inline]
-    fn vec_from_slice(_py: Python<'_>, slc: &[Self]) -> Vec<Self> {
-        slc.to_owned()
-    }
-
-    #[inline]
-    fn array_from_view<D>(
-        _py: Python<'_>,
-        view: ::ndarray::ArrayView<'_, Self, D>,
-    ) -> ::ndarray::Array<Self, D>
-    where
-        D: ::ndarray::Dimension,
-    {
-        view.to_owned()
-    }
-}
-
 unsafe impl<const N: usize> Element for PyFixedUnicode<N> {
     const IS_COPY: bool = true;
 
@@ -199,6 +155,8 @@ unsafe impl<const N: usize> Element for PyFixedUnicode<N> {
 
         unsafe { DTYPES.from_size(py, NPY_TYPES::NPY_UNICODE, b'=' as _, size_of::<Self>()) }
     }
+
+    clone_methods_impl!(Self);
 }
 
 struct TypeDescriptors {

--- a/src/sum_products.rs
+++ b/src/sum_products.rs
@@ -33,6 +33,10 @@ where
 impl<'py, T> ArrayOrScalar<'py, T> for T where T: Element + FromPyObject<'py> {}
 
 /// Deprecated form of [`inner_bound`]
+#[deprecated(
+    since = "0.21.0",
+    note = "will be replaced by `inner_bound` in the future"
+)]
 #[cfg(feature = "gil-refs")]
 pub fn inner<'py, T, DIN1, DIN2, OUT>(
     array1: &'py PyArray<T, DIN1>,
@@ -101,6 +105,10 @@ where
 
 /// Deprecated form of [`dot_bound`]
 #[cfg(feature = "gil-refs")]
+#[deprecated(
+    since = "0.21.0",
+    note = "will be replaced by `dot_bound` in the future"
+)]
 pub fn dot<'py, T, DIN1, DIN2, OUT>(
     array1: &'py PyArray<T, DIN1>,
     array2: &'py PyArray<T, DIN2>,
@@ -174,6 +182,10 @@ where
 
 /// Deprecated form of [`einsum_bound`]
 #[cfg(feature = "gil-refs")]
+#[deprecated(
+    since = "0.21.0",
+    note = "will be replaced by `einsum_bound` in the future"
+)]
 pub fn einsum<'py, T, OUT>(subscripts: &str, arrays: &[&'py PyArray<T, IxDyn>]) -> PyResult<OUT>
 where
     T: Element,
@@ -221,6 +233,10 @@ where
 
 /// Deprecated form of [`einsum_bound!`][crate::einsum_bound!]
 #[cfg(feature = "gil-refs")]
+#[deprecated(
+    since = "0.21.0",
+    note = "will be replaced by `einsum_bound!` in the future"
+)]
 #[macro_export]
 macro_rules! einsum {
     ($subscripts:literal $(,$array:ident)+ $(,)*) => {{

--- a/src/sum_products.rs
+++ b/src/sum_products.rs
@@ -4,7 +4,9 @@ use std::ptr::null_mut;
 
 use ndarray::{Dimension, IxDyn};
 use pyo3::types::PyAnyMethods;
-use pyo3::{Borrowed, Bound, FromPyObject, PyNativeType, PyResult};
+#[cfg(feature = "gil-refs")]
+use pyo3::PyNativeType;
+use pyo3::{Borrowed, Bound, FromPyObject, PyResult};
 
 use crate::array::PyArray;
 use crate::dtype::Element;
@@ -13,6 +15,7 @@ use crate::npyffi::{array::PY_ARRAY_API, NPY_CASTING, NPY_ORDER};
 /// Return value of a function that can yield either an array or a scalar.
 pub trait ArrayOrScalar<'py, T>: FromPyObject<'py> {}
 
+#[cfg(feature = "gil-refs")]
 impl<'py, T, D> ArrayOrScalar<'py, T> for &'py PyArray<T, D>
 where
     T: Element,
@@ -30,10 +33,7 @@ where
 impl<'py, T> ArrayOrScalar<'py, T> for T where T: Element + FromPyObject<'py> {}
 
 /// Deprecated form of [`inner_bound`]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `inner_bound` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 pub fn inner<'py, T, DIN1, DIN2, OUT>(
     array1: &'py PyArray<T, DIN1>,
     array2: &'py PyArray<T, DIN2>,
@@ -100,10 +100,7 @@ where
 }
 
 /// Deprecated form of [`dot_bound`]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `dot_bound` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 pub fn dot<'py, T, DIN1, DIN2, OUT>(
     array1: &'py PyArray<T, DIN1>,
     array2: &'py PyArray<T, DIN2>,
@@ -176,10 +173,7 @@ where
 }
 
 /// Deprecated form of [`einsum_bound`]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `einsum_bound` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 pub fn einsum<'py, T, OUT>(subscripts: &str, arrays: &[&'py PyArray<T, IxDyn>]) -> PyResult<OUT>
 where
     T: Element,
@@ -226,10 +220,7 @@ where
 }
 
 /// Deprecated form of [`einsum_bound!`][crate::einsum_bound!]
-#[deprecated(
-    since = "0.21.0",
-    note = "will be replaced by `einsum_bound!` in the future"
-)]
+#[cfg(feature = "gil-refs")]
 #[macro_export]
 macro_rules! einsum {
     ($subscripts:literal $(,$array:ident)+ $(,)*) => {{

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -3,9 +3,11 @@
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html
 use std::slice;
 
+#[cfg(feature = "gil-refs")]
+use pyo3::PyNativeType;
 use pyo3::{
     ffi, pyobject_native_type_extract, pyobject_native_type_named, types::PyAnyMethods,
-    AsPyPointer, Bound, IntoPy, PyAny, PyNativeType, PyObject, PyTypeInfo, Python,
+    AsPyPointer, Bound, IntoPy, PyAny, PyObject, PyTypeInfo, Python,
 };
 
 use crate::array::{PyArray, PyArrayMethods};
@@ -85,6 +87,7 @@ impl IntoPy<PyObject> for PyUntypedArray {
 
 pyobject_native_type_extract!(PyUntypedArray);
 
+#[cfg(feature = "gil-refs")]
 impl PyUntypedArray {
     /// Returns a raw pointer to the underlying [`PyArrayObject`][npyffi::PyArrayObject].
     #[inline]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -6,13 +6,15 @@ use ndarray::{array, s, Array1, Dim};
 use numpy::prelude::*;
 use numpy::{
     dtype_bound, get_array_module, npyffi::NPY_ORDER, pyarray_bound, PyArray, PyArray1, PyArray2,
-    PyArrayDescr, PyArrayDyn, PyFixedString, PyFixedUnicode,
+    PyArrayDescr, PyFixedString, PyFixedUnicode,
 };
 use pyo3::{
     py_run, pyclass, pymethods,
     types::{IntoPyDict, PyAnyMethods, PyDict, PyList},
-    Bound, Py, PyResult, Python,
+    Bound, Py, Python,
 };
+#[cfg(feature = "gil-refs")]
+use {numpy::PyArrayDyn, pyo3::PyResult};
 
 fn get_np_locals(py: Python<'_>) -> Bound<'_, PyDict> {
     [("np", get_array_module(py).unwrap())].into_py_dict_bound(py)

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -259,6 +259,7 @@ fn from_vec3_ragged() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_as_fixed() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -273,6 +274,7 @@ fn extract_as_fixed() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_as_dyn() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -294,6 +296,7 @@ fn extract_as_dyn() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_fail_by_check() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -311,6 +314,7 @@ fn extract_fail_by_check() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_fail_by_dim() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -328,6 +332,7 @@ fn extract_fail_by_dim() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn extract_fail_by_dtype() {
     Python::with_gil(|py| {
         let locals = get_np_locals(py);
@@ -474,6 +479,7 @@ fn unbind_works() {
 }
 
 #[test]
+#[cfg(feature = "gil-refs")]
 fn to_owned_works() {
     let arr: Py<PyArray1<_>> = Python::with_gil(|py| {
         let arr = PyArray::from_slice_bound(py, &[1_i32, 2, 3]);


### PR DESCRIPTION
This PR builds on #431 to migrate to PyO3 0.22.0 without needing to activate the problematic `py-clone` feature.

## Background
PyO3 recently released version 0.22.0 which includes [many new features](https://pyo3.rs/v0.22.0/changelog), but also includes the next step in deprecating the _gil-refs_ API by putting it behind the opt-in `gil-refs` feature flag. @bschoenmaeckers's PR went long way towards updating `numpy` for the migration by mirroring the gil-refs deprecation and feature-gating the methods that depend on it, but @juntyr raised valid concerns about its unconditional activation of  PyO3's `py-clone` feature flag.

## The problem with `py-clone`
The PyO3 0.22.0 release includes [PyO3#4095](https://github.com/PyO3/pyo3/pull/4095)'s removal of the ability to clone `Py<T>` while the GIL is not held, which was implemented by removing its `Clone` impl and requiring users  to either convert to `Bound<T>` before cloning or call the `clone_ref` method instead. The opt-in `py-clone` feature flag was added that restores the `Clone` implementation, but a panic is triggered if a clone is attempted while the GIL is not held. Enabling this feature may be convenient and fairly harmless in some use cases but can be hugely problematic in others, and we should not unconditionally impose  the risk of panicking clones on all `numpy` users.

#### Why not just add our own `py-clone` feature?
This was suggested in #431, but has a major problem related to the `Element` impl for `PyObject` (aka `Py<PyAny>`). The problem is that `Clone` is a supertrait of `Element`, so `PyObject` losing its `Clone` impl when the `py-clone` feature is disabled means its `Element` impl must be disabled as well. So if we made the feature _opt-in_ as was done by PyO3, then by default we would lose all support for object arrays which would be a huge regression. Making the feature _opt-out_ instead is also a bad option, so we need another way.

#### Could we implement `Element` for `Bound<PyAny>` instead?
No. Unfortunately `Bound<T>` does not (and can not) implement `Send`, which is another requirement for implementing `Element`. So retaining the `Element` impl for `PyObject` is our only option for supporting object arrays without major reworks.

## Eliminating our dependence on `py-clone`
The sad thing about this issue is that it really shouldn't be a problem in the context of `numpy` -- all of our API's require the GIL anyways, so it should always be safe to clone the `PyObject`s in our arrays. But that that doesn't help the fact that we still need a generic way to `clone` elements (and `to_owned` slices and array views), and we were relying on the `Element` trait's `Clone` requirement to do so. This PR solves the dilemma by replacing the `Clone` supertrait with a new trait `PyClone`, which can be safely implemented for `PyObject` and all existing `Element` impls.

#### The new `PyClone` trait
The new `PyClone` trait is a weaker form of the standard `Clone` trait that represents types which can be cloned while the GIL is held. Philosophically (though not in practice), this includes all `Clone` types that don't care about the GIL, as well as types like `Py<T>` that can only be cloned when it is held.

 The trait has the following (simplified) definition:
```rust
pub trait PyClone: Sized {
    /// Create a clone of the value while the GIL is guaranteed to be held.
    fn py_clone(&self, py: Python<'_>) -> Self;
}
```
Any type that implements `Clone` can trivially implement `PyClone` by ignoring the `py` argument and simply delegating to its `clone` method. Meanwhile, `PyObject` can implement this trait by using the provided `Python` token to call `Py::clone_ref`. The actual trait also defines a couple of methods (not shown above) for cloning collections, which have default implementations that types can override if there is a more efficient way to do so than simply mapping the `py_clone` method to each item.

Adding a trait like this to PyO3 was discussed in [PyO3#4133](https://github.com/PyO3/pyo3/issues/4133), but it is not clear if/when this would be implemented. If such a trait ends up getting added to PyO3 we can later transition to using it, but I don't think we should hold up `numpy`'s migration to 0.22.0 waiting for that to happen. 

#### Drawbacks
Ideally we would provide a blanket impl of `PyClone` for all `T: Clone` and then a specific impl for `PyObject`, which would let us avoid the breaking change for anyone with custom `Element` impls that will now need to add a `PyClone` impl as well. Unfortunately, this is not allowed due to possible impl overlaps since the compiler asserts that PyO3 restoring the `Clone` impl for `Py<T>` should not be a breaking change. If `PyClone` trait was instead defined in the `pyo3` crate then they _could_ provide these impls, but it is unlikely that they _would_ (as discussed in [PyO3#4133](https://github.com/PyO3/pyo3/issues/4133)) since it would prevent them from defining necessary generic impls for types like `Option<T: PyClone>`.

So, this will inevitably need to be a breaking change for downstream crates defining custom `Element` impls for their types. Luckily it extremely rare for crates to do this, and adding the `PyClone` impl is absolutely trivial in comparison to all the other changes needed to migrate away from the gil-refs API in the PyO3 0.21/0.22 updates anyways.

#### Patching `numpy` internals
As mentioned before, all of the `numpy` API's already require access to a `Python` token to prove that the GIL is held, so most of the necessary updates simply require replacing `item.clone()` calls with `item.py_clone(py)`.  The only exceptions are the calls to `<[T] as ToOwned>::to_owned` and `ArrayView::to_owned` (both of which require `T: Clone`), which now delegate to `PyClone`'s provided methods discussed above. Delegating to these collection-specific methods is used instead of simply mapping the `py_clone` method to avoid losing out on the optimized `to_owned` implementations for `Clone` types.

## Tasks
- [x] Deprecate the `gil-refs` API
  - [x] Add `gil-refs` feature guarding all usages of PyO3's gil-refs API (completed by @bschoenmaeckers)
  - [x] Update doctests and examples to use the bound API instead of gil-refs
- [x] Eliminate `py-clone` feature dependency 
  - [x] Add `PyClone` trait to replace `Clone` as a supertrait of `Element`
  - [x] Add `PyClone` impls for all internal `Element` types
  - [x] Update `numpy` internals to use `PyClone` instead of `Clone`
- [ ] Documentation
  - [x] Document the `PyClone` trait
  - [ ] Update the `Element` docs to reference the newly required supertrait
  - [ ] Create changelog and/or migration guide 
- [ ] Add tests -- the existing tests cover the changes pretty well, but there may be `PyClone`-specific tests worth adding.