### PR TITLE
Don't test against python 3.7 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         platform: [
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
           { os: "macOS-13",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
@@ -99,6 +99,9 @@ jobs:
     needs: [lint, check-msrv, examples]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
@@ -114,6 +117,9 @@ jobs:
     needs: [lint, check-msrv, examples]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
@@ -177,6 +183,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install OpenBLAS
         run: sudo apt install --yes libopenblas-dev
       - name: Install Rust
@@ -194,6 +203,9 @@ jobs:
     needs: [lint, check-msrv, examples]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install numpy
         run: pip install "numpy<2" ml_dtypes
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Python 3.7 is no longer available for `ubuntu-latest`, so drop it from the ci matrix. I've also added explicit `setup-python` steps for any job that needs to use pip, since python 3.12 on the current version of `ubuntu-latest` fails when trying to install in a system package directory. This is somewhat related to #445, though there may be other things we need to do in order to drop support for older pythons.