### PR TITLE
ci: bump versions in MSRV check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,8 @@ jobs:
         run: |
           import toml
           cargo_toml = toml.load("Cargo.toml")
-          cargo_toml["dependencies"]["ndarray"] = "0.13.1"
-          cargo_toml["dependencies"]["parking_lot"] = "0.11.2"
+          cargo_toml["dependencies"]["ndarray"] = "0.15.6"
           cargo_toml["dependencies"]["num-complex"] = "0.2.4"
-          cargo_toml["dependencies"]["once_cell"] = "1.14.0"
           with open("Cargo.toml", "w") as f:
             toml.dump(cargo_toml, f)
         working-directory: examples/simple
@@ -225,12 +223,8 @@ jobs:
           cargo_lock = toml.load("Cargo.lock")
           for pkg in cargo_lock["package"]:
             pkg_id = pkg["name"] + ":" + pkg["version"]
-            if pkg["name"] == "ndarray" and pkg["version"] != "0.13.1":
-              subprocess.run(["cargo", "update", "--package", pkg_id, "--precise", "0.13.1"], check=True)
-            elif pkg["name"] == "parking_lot" and pkg["version"] != "0.11.2":
-              subprocess.run(["cargo", "update", "--package", pkg_id, "--precise", "0.11.2"], check=True)
-            elif pkg["name"] == "once_cell" and pkg["version"] != "1.14.0":
-              subprocess.run(["cargo", "update", "--package", pkg_id, "--precise", "1.14.0"], check=True)
+            if pkg["name"] == "ndarray" and pkg["version"] != "0.15.6":
+              subprocess.run(["cargo", "update", "--package", pkg_id, "--precise", "0.15.6"], check=True)
         working-directory: examples/simple
         shell: python
       - name: Test example


### PR DESCRIPTION
Newer versions are now good enough following 1.63 bump.