### PR TITLE
Add method to clear `WRITEABLE` flag from `PyArray`

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -420,6 +420,9 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
 
     /// Creates a NumPy array backed by `array` and ties its ownership to the Python object `container`.
     ///
+    /// The resulting NumPy array will be writeable from Python space.  If this is undesireable, use
+    /// [PyReadwriteArray::make_nonwriteable].
+    ///
     /// # Safety
     ///
     /// `container` is set as a base object of the returned array which must not be dropped until `container` is dropped.

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -348,6 +348,20 @@ fn resize_using_exclusive_borrow() {
     });
 }
 
+#[test]
+fn can_make_python_array_nonwriteable() {
+    Python::with_gil(|py| {
+        let array = PyArray1::<f64>::zeros_bound(py, 10, false);
+        let locals = [("array", &array)].into_py_dict_bound(py);
+        array.readwrite().make_nonwriteable();
+        assert!(!py
+            .eval_bound("array.flags.writeable", None, Some(&locals))
+            .unwrap()
+            .extract::<bool>()
+            .unwrap())
+    })
+}
+
 #[cfg(feature = "nalgebra")]
 #[test]
 fn matrix_from_numpy() {


### PR DESCRIPTION
The `PyReadwriteArray` understands the flag during the dynamic borrow checking, this just adds a way to set it on an array as well.  This is a safe subset of what can be achieved unsafely by mutating the `flags` field on some `*mut PyArray`.

The discussion in #456 suggested having the method return a `PyReadonlyArray`.  I feel like I might be missing something _very_ obvious here, but I couldn't spot an existing way to consume an exclusive reference into a shared one.  I added a `From` impl and then used that for now, but happy to switch it to a better version if one already exists, or drop it if we decide we don't want users to always pay the cost of re-acquiring the shared borrow (maybe there's some `mem::forget` shenanigans in conjunction with an extra "switch in place" operation that could be added to `Shared` to reduce the cost).