### PR TITLE
release: 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- v0.22.1
+  - Fix building on 32-bit Windows. ([#463](https://github.com/PyO3/rust-numpy/pull/463))
+  - Add `PyReadwriteArray::make_nonwriteable`. ([#462](https://github.com/PyO3/rust-numpy/pull/462))
+  - Implement `From<PyReadWriteArray>` for `PyReadonlyArray`. ([#462](https://github.com/PyO3/rust-numpy/pull/462))
+
 - v0.22.0
   - Bump MSRV to 1.63. ([#450](https://github.com/PyO3/rust-numpy/pull/450))
   - Add `permute` and `transpose` methods for changing the order of axes of a `PyArray`. ([#428](https://github.com/PyO3/rust-numpy/pull/428))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.22.0"
+version = "0.22.1"
 authors = [
     "The rust-numpy Project Developers",
     "PyO3 Project and Contributors <https://github.com/PyO3>"


### PR DESCRIPTION
This releases the improvements by @jakelishman; notably the fixes to 32-bit windows but also the `PyReadWriteArray::make_nonwriteable` method.

I will put this live tonight unless I hear a reason to delay.