### PR TITLE
make `PySliceContainer` implement `Sync`

### DIFF
--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -697,7 +697,7 @@ impl Sealed for Bound<'_, PyArrayDescr> {}
 ///
 /// [enumerated-types]: https://numpy.org/doc/stable/reference/c-api/dtype.html#enumerated-types
 /// [data-models]: https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
-pub unsafe trait Element: Sized + Send {
+pub unsafe trait Element: Sized + Send + Sync {
     /// Flag that indicates whether this type is trivially copyable.
     ///
     /// It should be set to true for all trivially copyable types (like scalar types


### PR DESCRIPTION
Prepares for the `pyo3` upgrade to 0.23 in #457.

This contains two changes:

- This implements `Sync` for `PySliceContainer` which is used as the underlying backing object for Rust allocated `numpy` arrays.
Since `PySliceContainer` "virtually" does hold elements of type `T` (which is cast away due to the no-generics limitation), construction is only allowed from `T`s that are `Sync` themselves. (Ideally we would have `unsafe impl<T: Sync> Sync for PySliceContainer<T> {}`).

- I _think_ it will hand out references into that buffer in place, so we need to require all `Element`s to be `Sync` as well. In any case I think this could only be too strong, which would not be unsound.