### PR TITLE
support 3.13t free-threaded python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             "3.11",
             "3.12",
             "3.13",
+            "3.13t",
             "pypy-3.9",
             "pypy-3.10",
           ]
@@ -108,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - removed the `gil-refs` feature
     - reintroduced function names without `_bound` suffix + deprecating the old names
     - switched to `IntoPyObject` as trait bound
+  - Support Python 3.13t "free-threaded" Python. ([#471](https://github.com/PyO3/rust-numpy/pull/471)
 
 - v0.22.1
   - Fix building on 32-bit Windows. ([#463](https://github.com/PyO3/rust-numpy/pull/463))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,14 @@ num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
 pyo3 = { version = "0.23.0", default-features = false, features = ["macros"] }
 rustc-hash = "1.1"
+parking_lot = "0.12.3"
 
 [dev-dependencies]
 pyo3 = { version = "0.23.0", default-features = false, features = ["auto-initialize"] }
 nalgebra = { version = ">=0.30, <0.34", default-features = false, features = ["std"] }
+
+[build-dependencies]
+pyo3-build-config = { version = "0.23.1", features = ["resolve-config"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
 pyo3 = { version = "0.23.4", default-features = false, features = ["macros"] }
 rustc-hash = "2.0"
-parking_lot = "0.12.3"
 
 [dev-dependencies]
 pyo3 = { version = "0.23.3", default-features = false, features = ["auto-initialize"] }

--- a/benches/array.rs
+++ b/benches/array.rs
@@ -6,7 +6,7 @@ use test::{black_box, Bencher};
 use std::ops::Range;
 
 use numpy::{PyArray1, PyArray2, PyArray3};
-use pyo3::{types::PyAnyMethods, Bound, Python};
+use pyo3::{types::PyAnyMethods, Bound, IntoPyObjectExt, Python};
 
 #[bench]
 fn extract_success(bencher: &mut Bencher) {
@@ -115,7 +115,11 @@ fn from_slice_large(bencher: &mut Bencher) {
 }
 
 fn from_object_slice(bencher: &mut Bencher, size: usize) {
-    let vec = Python::with_gil(|py| (0..size).map(|val| val.to_object(py)).collect::<Vec<_>>());
+    let vec = Python::with_gil(|py| {
+        (0..size)
+            .map(|val| val.into_py_any(py).unwrap())
+            .collect::<Vec<_>>()
+    });
 
     Python::with_gil(|py| {
         bencher.iter(|| {

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::use_pyo3_cfgs();
+}

--- a/src/borrow/shared.rs
+++ b/src/borrow/shared.rs
@@ -463,7 +463,7 @@ mod tests {
             BorrowFlagsState(
                 inner.len(),
                 base_arrays.len(),
-                base_arrays.get(key).map(|x| *x),
+                base_arrays.get(key).copied(),
             )
         } else {
             BorrowFlagsState(0, 0, None)

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -53,7 +53,7 @@ macro_rules! impl_api {
     [$offset: expr; $fname: ident ($($arg: ident: $t: ty),* $(,)?) $(-> $ret: ty)?] => {
         #[allow(non_snake_case)]
         pub unsafe fn $fname<'py>(&self, py: Python<'py>, $($arg : $t), *) $(-> $ret)* {
-            let fptr = self.get(py, $offset) as *const extern fn ($($arg : $t), *) $(-> $ret)*;
+            let fptr = self.get(py, $offset) as *const extern "C" fn ($($arg : $t), *) $(-> $ret)*;
             (*fptr)($($arg), *)
         }
     };
@@ -69,7 +69,7 @@ macro_rules! impl_api {
                 API_VERSION_2_0,
                 *API_VERSION.get(py).expect("API_VERSION is initialized"),
             );
-            let fptr = self.get(py, $offset) as *const extern fn ($($arg: $t), *) $(-> $ret)*;
+            let fptr = self.get(py, $offset) as *const extern "C" fn ($($arg: $t), *) $(-> $ret)*;
             (*fptr)($($arg), *)
         }
 
@@ -84,7 +84,7 @@ macro_rules! impl_api {
                 API_VERSION_2_0,
                 *API_VERSION.get(py).expect("API_VERSION is initialized"),
             );
-            let fptr = self.get(py, $offset) as *const extern fn ($($arg: $t), *) $(-> $ret)*;
+            let fptr = self.get(py, $offset) as *const extern "C" fn ($($arg: $t), *) $(-> $ret)*;
             (*fptr)($($arg), *)
         }
 


### PR DESCRIPTION
First pass at adding CI and tests for freethreaded Python.

Locally I get some test failures, so I will have to investigate further before this is ready even if CI is green. cc @ngoldbaum 

```
failures:

---- borrow::shared::tests::borrow_multiple_views stdout ----
thread 'borrow::shared::tests::borrow_multiple_views' panicked at src/borrow/shared.rs:836:17:
assertion `left == right` failed
  left: 3
 right: 1

---- borrow::shared::tests::borrow_multiple_arrays stdout ----
thread 'borrow::shared::tests::borrow_multiple_arrays' panicked at src/borrow/shared.rs:786:17:
assertion `left == right` failed
  left: 2
 right: 1


failures:
    borrow::shared::tests::borrow_multiple_arrays
    borrow::shared::tests::borrow_multiple_views

test result: FAILED. 27 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
```