### PR TITLE
Update rustc-hash to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
 pyo3 = { version = "0.23.0", default-features = false, features = ["macros"] }
-rustc-hash = "1.1"
+rustc-hash = "2.0"
 
 [dev-dependencies]
 pyo3 = { version = "0.23.0", default-features = false, features = ["auto-initialize"] }


### PR DESCRIPTION
It [seems like](https://github.com/rust-lang/rustc-hash/blob/master/CHANGELOG.md) `rustc-hash`'s version 1.2 is yanked, which means this crate is stuck on 1.1.

I don't think there is any harm in updating version 2.0, should hopefully give a small speedup.

