### PR TITLE
release: 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - removed the `gil-refs` feature
     - reintroduced function names without `_bound` suffix + deprecating the old names
     - switched to `IntoPyObject` as trait bound
+  - Bump `rustc-hash` dependency to 2.0. ([[#472](https://github.com/PyO3/rust-numpy/pull/472)])
 
 - v0.22.1
   - Fix building on 32-bit Windows. ([#463](https://github.com/PyO3/rust-numpy/pull/463))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.23.0-dev"
+version = "0.23.0"
 authors = [
     "The rust-numpy Project Developers",
     "PyO3 Project and Contributors <https://github.com/PyO3>"


### PR DESCRIPTION
I think we're ready to ship the 0.23 release.

Free-threading support looks non-trivial; without the changes in #471 it won't even build so we are safe to release and fixup later, I believe.

If I hear no concerns will put this live on either Thursday or Friday.