### PR TITLE
Opt-in feature to enable pyo3/multiple-pymethods feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ all-features = true
 
 [features]
 gil-refs = ["pyo3/gil-refs"]
+multiple-pymethods = ["pyo3/multiple-pymethods"]


### PR DESCRIPTION
Hi there,

# Context 

We’ve encountered an issue while using the rust-numpy crate in conjunction with the pyo3 [multiple-pymethods](https://pyo3.rs/v0.23.2/features.html#multiple-pymethods) feature in one of our internal projects. This feature is essential for implementing methods on a structure across multiple files, which helps in organizing larger codebases. However, since rust-numpy does not currently enable this feature, it caused conflicts when trying to use both crates together.

# Reproducible example
[reproducible_example.zip](https://github.com/user-attachments/files/18039267/reproducible_example.zip)


# What this pull request does
Simply adds a opt-in `multiple-pymethods` feature to enable the `pyo3/multiple-pymethods` feature.

We believe this change will improve the usability of rust-numpy for users with similar requirements 
Thank you for considering this PR!

Best regards,
Nuant Team
