### PR TITLE
Adds into_pyarray to faer Mat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,16 @@ license = "BSD-2-Clause"
 half = { version = "2.0", default-features = false, optional = true }
 libc = "0.2"
 nalgebra = { version = ">=0.30, <0.34", default-features = false, optional = true }
+faer = { version = "0.21", optional = true }
 num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
 pyo3 = { version = "0.23.4", default-features = false, features = ["macros"] }
 rustc-hash = "2.0"
+
+[features]
+faer = ["dep:faer"]
 
 [dev-dependencies]
 pyo3 = { version = "0.23.3", default-features = false, features = ["auto-initialize"] }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -287,6 +287,32 @@ fn slice_container_type_confusion() {
         let _py_arr = vec![1, 2, 3].into_pyarray(py);
     });
 }
+#[cfg(feature = "faer")]
+#[test]
+fn faer_mat_to_numpy() {
+    let faer_mat: faer::Mat<f64> = faer::Scale(2.0)*faer::mat::Mat::<f64>::identity(2, 2);
+    let faer_mat_wide: faer::Mat<f64> = faer::mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+    let faer_mat_tall: faer::Mat<f64> = faer_mat_wide.transpose().to_owned();
+    Python::with_gil(|py| {
+        let mat_pyarray = faer_mat.into_pyarray(py);
+        let mat_wide_pyarray = faer_mat_wide.into_pyarray(py);
+        let mat_tall_pyarray = faer_mat_tall.into_pyarray(py);
+        assert_eq!(
+            mat_pyarray.readonly().as_array(),
+            array![[2.0f64, 0.0f64], [0.0f64, 2.0f64]]
+        );
+        assert_eq!(
+            mat_wide_pyarray.readonly().as_array(),
+            array![[1.0f64, 2.0, 3.0], [4.0, 5.0, 6.0]]
+        );
+        assert_eq!(
+            mat_tall_pyarray.readonly().as_array(),
+            array![[1.0f64, 4.0],
+                   [2.0,    5.0],
+                   [3.0,    6.0]]
+        );
+    });
+}
 
 #[cfg(feature = "nalgebra")]
 #[test]


### PR DESCRIPTION
Interoperability with faer (https://github.com/sarah-quinones/faer-rs) Mats.

Related faer-ext PR for numpy-to-faer direction: https://github.com/sarah-quinones/faer-ext/pull/6 .   For bi-directional interoperability of faer with python/numpy. 