### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
-pyo3 = { version = "0.24", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.24.1", default-features = false, features = ["macros"] }
 rustc-hash = "2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Bumps the dependency to at least 0.24.1 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2025-0020.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)