### PR TITLE
fix lint warning with Rust 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "numpy"
 version = "0.25.0"
 authors = [
     "The rust-numpy Project Developers",
-    "PyO3 Project and Contributors <https://github.com/PyO3>"
+    "PyO3 Project and Contributors <https://github.com/PyO3>",
 ]
 description = "PyO3-based Rust bindings of the NumPy C-API"
 documentation = "https://docs.rs/numpy"
@@ -26,11 +26,22 @@ pyo3 = { version = "0.25.0", default-features = false, features = ["macros"] }
 rustc-hash = "2.0"
 
 [dev-dependencies]
-pyo3 = { version = "0.25", default-features = false, features = ["auto-initialize"] }
-nalgebra = { version = ">=0.30, <0.34", default-features = false, features = ["std"] }
+pyo3 = { version = "0.25", default-features = false, features = [
+    "auto-initialize",
+] }
+nalgebra = { version = ">=0.30, <0.34", default-features = false, features = [
+    "std",
+] }
 
 [build-dependencies]
 pyo3-build-config = { version = "0.25", features = ["resolve-config"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints.rust]
+# We usually want to make the GIL lifetime explicit.
+elided-lifetimes-in-paths = "deny"
+
+[lints.clippy]
+needless-lifetimes = "allow"

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -241,7 +241,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
 
     /// Returns `true` if the there are no elements in the array.
     fn is_empty(&self) -> bool {
-        self.shape().iter().any(|dim| *dim == 0)
+        self.shape().contains(&0)
     }
 }
 

--- a/x.py
+++ b/x.py
@@ -29,15 +29,7 @@ def gen_examples(manifest):
         yield dir_ / manifest
 
 
-LINT_CONFIG = (
-    "--deny",
-    "warnings",
-    # We usually want to make the GIL lifetime explicit.
-    "--deny",
-    "elided-lifetimes-in-paths",
-    "--allow",
-    "clippy::needless-lifetimes",
-)
+DENY_WARNINGS = ("--deny", "warnings")
 
 
 def default(args):
@@ -51,40 +43,24 @@ def default(args):
             "--tests",
             "--benches",
             "--",
-            *LINT_CONFIG,
+            *DENY_WARNINGS,
         )
     else:
-        run("cargo", "clippy", "--all-features", "--tests", "--", *LINT_CONFIG)
+        run("cargo", "clippy", "--all-features", "--tests", "--", *DENY_WARNINGS)
 
     for manifest in gen_examples("Cargo.toml"):
-        run("cargo", "clippy", "--manifest-path", manifest, "--", *LINT_CONFIG)
+        run("cargo", "clippy", "--manifest-path", manifest, "--", *DENY_WARNINGS)
 
     run("cargo", "test", "--all-features", "--lib", "--tests")
 
 
 def check(args):
     run("cargo", "fmt", "--", "--check")
-
-    run(
-        "cargo",
-        "clippy",
-        "--all-features",
-        "--tests",
-        "--",
-        *LINT_CONFIG,
-    )
+    run("cargo", "clippy", "--all-features", "--tests", "--", *DENY_WARNINGS)
 
     for manifest in gen_examples("Cargo.toml"):
         run("cargo", "fmt", "--manifest-path", manifest, "--", "--check")
-
-        run(
-            "cargo",
-            "clippy",
-            "--manifest-path",
-            manifest,
-            "--",
-            *LINT_CONFIG,
-        )
+        run("cargo", "clippy", "--manifest-path", manifest, "--", *DENY_WARNINGS)
 
 
 def doc(args):


### PR DESCRIPTION
Fixes the CI lint warning with 1.87. Also elides a bunch of needless named lifetimes at the same time.