### PR TITLE
Pin rustc-hash to >=2,<3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
 pyo3 = { version = "0.25.0", default-features = false, features = ["macros"] }
-rustc-hash = "2.1"
+rustc-hash = "2"
 
 [dev-dependencies]
 pyo3 = { version = "0.25", default-features = false, features = [


### PR DESCRIPTION
Trying to fix a dependency conflict with another crate that relies on [`bindgen`](https://github.com/rust-lang/rust-bindgen) which pins to [`rustc-hash=2.1.0`](https://github.com/rust-lang/rust-bindgen/blob/97ab9152b5edb1fda1ced9bc1604f5e4dc9cfaa9/Cargo.toml#L44):

```
error: failed to select a version for `rustc-hash`.
    ... required by package `bindgen v0.71.1`
    ... which satisfies dependency `bindgen = "^0.71.1"` of package `XXX-sys v0.1.0 (...)`
    ... which satisfies git dependency `XXX-sys` of package `YYY v0.1.0 (...)`
versions that meet the requirements `^2.1.0` are: 2.1.1, 2.1.0

all possible versions conflict with previously selected packages.

  previously selected package `rustc-hash v2.0.0`
    ... which satisfies dependency `rustc-hash = "^2.0"` (locked to 2.0.0) of package `numpy v0.25.0`
    ... which satisfies dependency `numpy = "^0.25.0"` (locked to 0.25.0) of package `YYY v0.1.0 (...)`

failed to select a version for `rustc-hash` which could resolve this conflict
```

Bumps [rustc-hash](https://github.com/rust-lang/rustc-hash) from 2.0.0 to 2.1.1.
- [Changelog](https://github.com/rust-lang/rustc-hash/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/rustc-hash/compare/v2.0.0...v2.1.1)

Previous PR at #472