### PR TITLE
Upgrade to PyO3 0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - v0.26.0
   - bump MSRV to 1.74, matching PyO3 ([#504](https://github.com/PyO3/rust-numpy/pull/504))
   - extend supported `nalgebra` version to `0.34` ([#503](https://github.com/PyO3/rust-numpy/pull/503))
+  - Bump PyO3 dependency to v0.26.0. ([#506](https://github.com/PyO3/rust-numpy/pull/506))
 
 - v0.25.0,
   - Bump PyO3 dependency to v0.25.0. ([#492](https://github.com/PyO3/rust-numpy/pull/492))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.25.0"
+version = "0.26.0"
 authors = [
     "The rust-numpy Project Developers",
     "PyO3 Project and Contributors <https://github.com/PyO3>",
@@ -22,11 +22,11 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, < 0.17"
-pyo3 = { version = "0.25.0", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.26.0", default-features = false, features = ["macros"]}
 rustc-hash = "2.0"
 
 [dev-dependencies]
-pyo3 = { version = "0.25", default-features = false, features = [
+pyo3 = { version = "0.26.0", default-features = false, features = [
     "auto-initialize",
 ] }
 nalgebra = { version = ">=0.30, <0.35", default-features = false, features = [
@@ -34,7 +34,7 @@ nalgebra = { version = ">=0.30, <0.35", default-features = false, features = [
 ] }
 
 [build-dependencies]
-pyo3-build-config = { version = "0.25", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.26", features = ["resolve-config"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ use numpy::{PyArray1, PyArrayMethods};
 use pyo3::{types::{IntoPyDict, PyAnyMethods}, PyResult, Python, ffi::c_str};
 
 fn main() -> PyResult<()> {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let np = py.import("numpy")?;
         let locals = [("np", np)].into_py_dict(py)?;
 
         let pyarray = py
             .eval(c_str!("np.absolute(np.array([-1, -2, -3], dtype='int32'))"), Some(&locals), None)?
-            .downcast_into::<PyArray1<i32>>()?;
+            .cast_into::<PyArray1<i32>>()?;
 
         let readonly = pyarray.readonly();
         let slice = readonly.as_slice()?;

--- a/benches/array.rs
+++ b/benches/array.rs
@@ -10,7 +10,7 @@ use pyo3::{types::PyAnyMethods, Bound, IntoPyObjectExt, Python};
 
 #[bench]
 fn extract_success(bencher: &mut Bencher) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyArray2::<f64>::zeros(py, (10, 10), false).into_any();
 
         bencher.iter(|| {
@@ -23,7 +23,7 @@ fn extract_success(bencher: &mut Bencher) {
 
 #[bench]
 fn extract_failure(bencher: &mut Bencher) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyArray2::<f64>::zeros(py, (10, 10), false).into_any();
 
         bencher.iter(|| {
@@ -35,20 +35,20 @@ fn extract_failure(bencher: &mut Bencher) {
 }
 
 #[bench]
-fn downcast_success(bencher: &mut Bencher) {
-    Python::with_gil(|py| {
+fn cast_success(bencher: &mut Bencher) {
+    Python::attach(|py| {
         let any = PyArray2::<f64>::zeros(py, (10, 10), false).into_any();
 
-        bencher.iter(|| black_box(&any).downcast::<PyArray2<f64>>().unwrap());
+        bencher.iter(|| black_box(&any).cast::<PyArray2<f64>>().unwrap());
     });
 }
 
 #[bench]
-fn downcast_failure(bencher: &mut Bencher) {
-    Python::with_gil(|py| {
+fn cast_failure(bencher: &mut Bencher) {
+    Python::attach(|py| {
         let any = PyArray2::<f64>::zeros(py, (10, 10), false).into_any();
 
-        bencher.iter(|| black_box(&any).downcast::<PyArray2<f64>>().unwrap_err());
+        bencher.iter(|| black_box(&any).cast::<PyArray2<f64>>().unwrap_err());
     });
 }
 
@@ -63,7 +63,7 @@ impl Iterator for Iter {
 }
 
 fn from_iter(bencher: &mut Bencher, size: usize) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         bencher.iter(|| {
             let iter = black_box(Iter(0..size));
 
@@ -90,7 +90,7 @@ fn from_iter_large(bencher: &mut Bencher) {
 fn from_slice(bencher: &mut Bencher, size: usize) {
     let vec = (0..size).collect::<Vec<_>>();
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         bencher.iter(|| {
             let slice = black_box(&vec);
 
@@ -115,13 +115,13 @@ fn from_slice_large(bencher: &mut Bencher) {
 }
 
 fn from_object_slice(bencher: &mut Bencher, size: usize) {
-    let vec = Python::with_gil(|py| {
+    let vec = Python::attach(|py| {
         (0..size)
             .map(|val| val.into_py_any(py).unwrap())
             .collect::<Vec<_>>()
     });
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         bencher.iter(|| {
             let slice = black_box(&vec);
 
@@ -148,7 +148,7 @@ fn from_object_slice_large(bencher: &mut Bencher) {
 fn from_vec2(bencher: &mut Bencher, size: usize) {
     let vec2 = vec![vec![0; size]; size];
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         bencher.iter(|| {
             let vec2 = black_box(&vec2);
 
@@ -175,7 +175,7 @@ fn from_vec2_large(bencher: &mut Bencher) {
 fn from_vec3(bencher: &mut Bencher, size: usize) {
     let vec3 = vec![vec![vec![0; size]; size]; size];
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         bencher.iter(|| {
             let vec3 = black_box(&vec3);
 

--- a/benches/borrow.rs
+++ b/benches/borrow.rs
@@ -8,7 +8,7 @@ use pyo3::Python;
 
 #[bench]
 fn initial_shared_borrow(bencher: &mut Bencher) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = PyArray::<f64, _>::zeros(py, (6, 5, 4, 3, 2, 1), false);
 
         bencher.iter(|| {
@@ -21,7 +21,7 @@ fn initial_shared_borrow(bencher: &mut Bencher) {
 
 #[bench]
 fn additional_shared_borrow(bencher: &mut Bencher) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = PyArray::<f64, _>::zeros(py, (6, 5, 4, 3, 2, 1), false);
 
         let _shared = (0..128).map(|_| array.readonly()).collect::<Vec<_>>();
@@ -36,7 +36,7 @@ fn additional_shared_borrow(bencher: &mut Bencher) {
 
 #[bench]
 fn exclusive_borrow(bencher: &mut Bencher) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = PyArray::<f64, _>::zeros(py, (6, 5, 4, 3, 2, 1), false);
 
         bencher.iter(|| {

--- a/examples/linalg/Cargo.lock
+++ b/examples/linalg/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.24.0"
+version = "0.26.0"
 dependencies = [
  "libc",
  "ndarray",
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openblas-build"
@@ -524,11 +524,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -542,19 +541,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -562,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -574,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_linalg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.25.0", features = ["extension-module"] }
+pyo3 = { version = "0.26.0", features = ["extension-module"] }
 numpy = { path = "../.." }
 ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
 

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_parallel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.25.0", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.26.0", features = ["extension-module", "multiple-pymethods"] }
 numpy = { path = "../.." }
 ndarray = { version = "0.16", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.25.0", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py37"] }
 numpy = { path = "../.." }
 
 [workspace]

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -23,7 +23,7 @@ use crate::slice_container::PySliceContainer;
 /// use numpy::{PyArray, IntoPyArray, PyArrayMethods};
 /// use pyo3::Python;
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let py_array = vec![1, 2, 3].into_pyarray(py);
 ///
 ///     assert_eq!(py_array.readonly().as_slice().unwrap(), &[1, 2, 3]);
@@ -103,7 +103,7 @@ where
 /// use numpy::{PyArray, ToPyArray, PyArrayMethods};
 /// use pyo3::Python;
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let py_array = vec![1, 2, 3].to_pyarray(py);
 ///
 ///     assert_eq!(py_array.readonly().as_slice().unwrap(), &[1, 2, 3]);
@@ -118,7 +118,7 @@ where
 /// use ndarray::{arr3, s};
 /// use pyo3::Python;
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let array = arr3(&[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]);
 ///     let py_array = array.slice(s![.., 0..1, ..]).to_pyarray(py);
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fmt;
 
 use pyo3::{
-    conversion::IntoPyObject, exceptions::PyTypeError, Bound, Py, PyErr, PyErrArguments, PyObject,
+    conversion::IntoPyObject, exceptions::PyTypeError, Bound, Py, PyAny, PyErr, PyErrArguments,
     Python,
 };
 
@@ -22,7 +22,7 @@ macro_rules! impl_pyerr {
         impl Error for $err_type {}
 
         impl PyErrArguments for $err_type {
-            fn arguments<'py>(self, py: Python<'py>) -> PyObject {
+            fn arguments<'py>(self, py: Python<'py>) -> Py<PyAny> {
                 self.to_string()
                     .into_pyobject(py)
                     .unwrap()
@@ -91,7 +91,7 @@ struct TypeErrorArguments {
 }
 
 impl PyErrArguments for TypeErrorArguments {
-    fn arguments<'py>(self, py: Python<'py>) -> PyObject {
+    fn arguments<'py>(self, py: Python<'py>) -> Py<PyAny> {
         let err = TypeError {
             from: self.from.into_bound(py),
             to: self.to.into_bound(py),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //! use numpy::ndarray::array;
 //! use numpy::{ToPyArray, PyArray, PyArrayMethods};
 //!
-//! Python::with_gil(|py| {
+//! Python::attach(|py| {
 //!     let py_array = array![[1i64, 2], [3, 4]].to_pyarray(py);
 //!
 //!     assert_eq!(
@@ -41,7 +41,7 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //! use numpy::nalgebra::Matrix3;
 //! use numpy::{pyarray, ToPyArray, PyArrayMethods};
 //!
-//! Python::with_gil(|py| {
+//! Python::attach(|py| {
 //!     let py_array = pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
 //!
 //!     let py_array_square;
@@ -156,7 +156,7 @@ fn cold() {}
 /// use numpy::ndarray::array;
 /// use numpy::{pyarray, PyArrayMethods};
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let array = pyarray![py, [1, 2], [3, 4]];
 ///
 ///     assert_eq!(

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -13,14 +13,14 @@ use std::mem::forget;
 use std::os::raw::{c_uint, c_void};
 
 use pyo3::{
-    sync::GILOnceCell,
+    sync::PyOnceLock,
     types::{PyAnyMethods, PyCapsule, PyCapsuleMethods, PyModule},
     PyResult, Python,
 };
 
 pub const API_VERSION_2_0: c_uint = 0x00000012;
 
-static API_VERSION: GILOnceCell<c_uint> = GILOnceCell::new();
+static API_VERSION: PyOnceLock<c_uint> = PyOnceLock::new();
 
 fn get_numpy_api<'py>(
     py: Python<'py>,
@@ -28,7 +28,7 @@ fn get_numpy_api<'py>(
     capsule: &str,
 ) -> PyResult<*const *const c_void> {
     let module = PyModule::import(py, module)?;
-    let capsule = module.getattr(capsule)?.downcast_into::<PyCapsule>()?;
+    let capsule = module.getattr(capsule)?.cast_into::<PyCapsule>()?;
 
     let api = capsule.pointer() as *const *const c_void;
 

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -2,12 +2,12 @@
 
 use std::os::raw::*;
 
-use pyo3::{ffi::PyObject, sync::GILOnceCell};
+use pyo3::{ffi::PyObject, sync::PyOnceLock};
 
 use crate::npyffi::*;
 
 fn mod_name(py: Python<'_>) -> PyResult<&'static str> {
-    static MOD_NAME: GILOnceCell<String> = GILOnceCell::new();
+    static MOD_NAME: PyOnceLock<String> = PyOnceLock::new();
     MOD_NAME
         .get_or_try_init(py, || {
             let numpy_core = super::array::numpy_core_name(py)?;
@@ -20,9 +20,9 @@ const CAPSULE_NAME: &str = "_UFUNC_API";
 
 /// A global variable which stores a ['capsule'](https://docs.python.org/3/c-api/capsule.html)
 /// pointer to [Numpy UFunc API](https://numpy.org/doc/stable/reference/c-api/ufunc.html).
-pub static PY_UFUNC_API: PyUFuncAPI = PyUFuncAPI(GILOnceCell::new());
+pub static PY_UFUNC_API: PyUFuncAPI = PyUFuncAPI(PyOnceLock::new());
 
-pub struct PyUFuncAPI(GILOnceCell<*const *const c_void>);
+pub struct PyUFuncAPI(PyOnceLock<*const *const c_void>);
 
 unsafe impl Send for PyUFuncAPI {}
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -50,7 +50,7 @@ use crate::npyffi::NPY_TYPES;
 /// # use pyo3::Python;
 /// use numpy::{PyArray1, PyUntypedArrayMethods, PyFixedString};
 ///
-/// # Python::with_gil(|py| {
+/// # Python::attach(|py| {
 /// let array = PyArray1::<PyFixedString<3>>::from_vec(py, vec![[b'f', b'o', b'o'].into()]);
 ///
 /// assert!(array.dtype().to_string().contains("S3"));
@@ -115,7 +115,7 @@ unsafe impl<const N: usize> Element for PyFixedString<N> {
 /// # use pyo3::Python;
 /// use numpy::{PyArray1, PyUntypedArrayMethods, PyFixedUnicode};
 ///
-/// # Python::with_gil(|py| {
+/// # Python::attach(|py| {
 /// let array = PyArray1::<PyFixedUnicode<3>>::from_vec(py, vec![[b'b' as _, b'a' as _, b'r' as _].into()]);
 ///
 /// assert!(array.dtype().to_string().contains("U3"));

--- a/src/sum_products.rs
+++ b/src/sum_products.rs
@@ -34,7 +34,7 @@ impl<'py, T> ArrayOrScalar<'py, T> for T where T: Element + FromPyObject<'py> {}
 /// use pyo3::Python;
 /// use numpy::{inner, pyarray, PyArray0};
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let vector = pyarray![py, 1.0, 2.0, 3.0];
 ///     let result: f64 = inner(&vector, &vector).unwrap();
 ///     assert_eq!(result, 14.0);
@@ -48,7 +48,7 @@ impl<'py, T> ArrayOrScalar<'py, T> for T where T: Element + FromPyObject<'py> {}
 /// use numpy::prelude::*;
 /// use numpy::{inner, pyarray, PyArray0};
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let vector = pyarray![py, 1, 2, 3];
 ///     let result: Bound<'_, PyArray0<_>> = inner(&vector, &vector).unwrap();
 ///     assert_eq!(result.item(), 14);
@@ -87,7 +87,7 @@ where
 /// use ndarray::array;
 /// use numpy::{dot, pyarray, PyArray2, PyArrayMethods};
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let matrix = pyarray![py, [1, 0], [0, 1]];
 ///     let another_matrix = pyarray![py, [4, 1], [2, 2]];
 ///
@@ -106,7 +106,7 @@ where
 /// use pyo3::Python;
 /// use numpy::{dot, pyarray, PyArray0};
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let vector = pyarray![py, 1.0, 2.0, 3.0];
 ///     let result: f64 = dot(&vector, &vector).unwrap();
 ///     assert_eq!(result, 14.0);
@@ -177,7 +177,7 @@ where
 /// use ndarray::array;
 /// use numpy::{einsum, pyarray, PyArray, PyArray2, PyArrayMethods};
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let tensor = PyArray::arange(py, 0, 2 * 3 * 4, 1).reshape([2, 3, 4]).unwrap();
 ///     let another_tensor = pyarray![py, [20, 30], [40, 50], [60, 70]];
 ///

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -3,9 +3,7 @@
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html
 use std::slice;
 
-use pyo3::{
-    ffi, pyobject_native_type_named, types::PyAnyMethods, Bound, PyAny, PyTypeInfo, Python,
-};
+use pyo3::{ffi, pyobject_native_type_named, Bound, PyAny, PyTypeInfo, Python};
 
 use crate::array::{PyArray, PyArrayMethods};
 use crate::cold;
@@ -41,11 +39,11 @@ use crate::npyffi;
 ///     let element_type = array.dtype();
 ///
 ///     if element_type.is_equiv_to(&dtype::<f32>(py)) {
-///         let array = array.downcast::<PyArray1<f32>>()?;
+///         let array = array.cast::<PyArray1<f32>>()?;
 ///
 ///         implementation(array)
 ///     } else if element_type.is_equiv_to(&dtype::<f64>(py)) {
-///         let array = array.downcast::<PyArray1<f64>>()?;
+///         let array = array.cast::<PyArray1<f64>>()?;
 ///
 ///         implementation(array)
 ///     } else {
@@ -53,7 +51,7 @@ use crate::npyffi;
 ///     }
 /// }
 /// #
-/// # Python::with_gil(|py| {
+/// # Python::attach(|py| {
 /// #   let array = PyArray1::<f64>::zeros(py, 42, false);
 /// #   entry_point(py, array.as_untyped())
 /// # }).unwrap();
@@ -93,7 +91,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
     /// use numpy::{dtype, PyArray};
     /// use pyo3::Python;
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///    let array = PyArray::from_vec(py, vec![1_i32, 2, 3]);
     ///
     ///    assert!(array.dtype().is_equiv_to(&dtype::<i32>(py)));
@@ -114,13 +112,13 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
     /// use pyo3::{types::{IntoPyDict, PyAnyMethods}, Python, ffi::c_str};
     ///
     /// # fn main() -> pyo3::PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let array = PyArray1::arange(py, 0, 10, 1);
     ///     assert!(array.is_contiguous());
     ///
     ///     let view = py
     ///         .eval(c_str!("array[::2]"), None, Some(&[("array", array)].into_py_dict(py)?))?
-    ///         .downcast_into::<PyArray1<i32>>()?;
+    ///         .cast_into::<PyArray1<i32>>()?;
     ///     assert!(!view.is_contiguous());
     /// #   Ok(())
     /// })
@@ -155,7 +153,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
     /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.ndim(), 3);
@@ -179,7 +177,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
     /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.strides(), &[240, 48, 8]);
@@ -211,7 +209,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
     /// use numpy::{PyArray3, PyUntypedArrayMethods};
     /// use pyo3::Python;
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let arr = PyArray3::<f64>::zeros(py, [4, 5, 6], false);
     ///
     ///     assert_eq!(arr.shape(), &[4, 5, 6]);
@@ -264,7 +262,7 @@ impl<'py> PyUntypedArrayMethods<'py> for Bound<'py, PyUntypedArray> {
     fn dtype(&self) -> Bound<'py, PyArrayDescr> {
         unsafe {
             let descr_ptr = (*self.as_array_ptr()).descr;
-            Bound::from_borrowed_ptr(self.py(), descr_ptr.cast()).downcast_into_unchecked()
+            Bound::from_borrowed_ptr(self.py(), descr_ptr.cast()).cast_into_unchecked()
         }
     }
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -28,13 +28,13 @@ fn not_contiguous_array(py: Python<'_>) -> Bound<'_, PyArray1<i32>> {
         Some(&get_np_locals(py)),
     )
     .unwrap()
-    .downcast_into()
+    .cast_into()
     .unwrap()
 }
 
 #[test]
 fn new_c_order() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dims = [3, 5];
 
         let arr = PyArray::<f64, _>::zeros(py, dims, false);
@@ -56,7 +56,7 @@ fn new_c_order() {
 
 #[test]
 fn new_fortran_order() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dims = [3, 5];
 
         let arr = PyArray::<f64, _>::zeros(py, dims, true);
@@ -78,7 +78,7 @@ fn new_fortran_order() {
 
 #[test]
 fn tuple_as_dim() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dims = (3, 5);
 
         let arr = PyArray::<f64, _>::zeros(py, dims, false);
@@ -90,7 +90,7 @@ fn tuple_as_dim() {
 
 #[test]
 fn rank_zero_array_has_invalid_strides_dimensions() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = PyArray::<f64, _>::zeros(py, (), false);
 
         assert_eq!(arr.ndim(), 0);
@@ -106,7 +106,7 @@ fn rank_zero_array_has_invalid_strides_dimensions() {
 
 #[test]
 fn zeros() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dims = [3, 4];
 
         let arr = PyArray::<f64, _>::zeros(py, dims, false);
@@ -129,7 +129,7 @@ fn zeros() {
 
 #[test]
 fn arange() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = PyArray::<f64, _>::arange(py, 0.0, 1.0, 0.1);
 
         assert_eq!(arr.ndim(), 1);
@@ -139,7 +139,7 @@ fn arange() {
 
 #[test]
 fn as_array() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyarr = PyArray::<f64, _>::zeros(py, [3, 2, 4], false).readonly();
         let arr = pyarr.as_array();
 
@@ -160,7 +160,7 @@ fn as_array() {
 
 #[test]
 fn as_raw_array() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let not_contiguous = not_contiguous_array(py);
 
         let raw_array_view = not_contiguous.as_raw_array();
@@ -173,7 +173,7 @@ fn as_raw_array() {
 
 #[test]
 fn as_slice() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = PyArray::<i32, _>::zeros(py, [3, 2, 4], false);
         assert_eq!(arr.readonly().as_slice().unwrap().len(), 3 * 2 * 4);
 
@@ -185,7 +185,7 @@ fn as_slice() {
 
 #[test]
 fn is_instance() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = PyArray2::<f64>::zeros(py, [3, 5], false);
 
         assert!(arr.is_instance_of::<PyArray2<f64>>());
@@ -195,7 +195,7 @@ fn is_instance() {
 
 #[test]
 fn from_vec2() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyarray = PyArray::from_vec2(py, &[vec![1, 2, 3], vec![4, 5, 6]]).unwrap();
 
         assert_eq!(pyarray.readonly().as_array(), array![[1, 2, 3], [4, 5, 6]]);
@@ -204,7 +204,7 @@ fn from_vec2() {
 
 #[test]
 fn from_vec2_ragged() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyarray = PyArray::from_vec2(py, &[vec![1, 2, 3], vec![4, 5]]);
 
         let err = pyarray.unwrap_err();
@@ -214,7 +214,7 @@ fn from_vec2_ragged() {
 
 #[test]
 fn from_vec3() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyarray = PyArray::from_vec3(
             py,
             &[
@@ -234,7 +234,7 @@ fn from_vec3() {
 
 #[test]
 fn from_vec3_ragged() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyarray = PyArray::from_vec3(
             py,
             &[
@@ -263,9 +263,9 @@ fn from_vec3_ragged() {
 
 #[test]
 fn array_cast() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr_f64 = pyarray![py, [1.5, 2.5, 3.5], [1.5, 2.5, 3.5]];
-        let arr_i32 = arr_f64.cast::<i32>(false).unwrap();
+        let arr_i32 = arr_f64.cast_array::<i32>(false).unwrap();
 
         assert_eq!(arr_i32.readonly().as_array(), array![[1, 2, 3], [1, 2, 3]]);
     });
@@ -273,7 +273,7 @@ fn array_cast() {
 
 #[test]
 fn handle_negative_strides() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = array![[2, 3], [4, 5u32]];
         let pyarr = arr.to_pyarray(py);
 
@@ -284,7 +284,7 @@ fn handle_negative_strides() {
                 None,
             )
             .unwrap()
-            .downcast_into::<PyArray2<u32>>()
+            .cast_into::<PyArray2<u32>>()
             .unwrap();
 
         assert_eq!(
@@ -296,7 +296,7 @@ fn handle_negative_strides() {
 
 #[test]
 fn dtype_via_python_attribute() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = array![[2, 3], [4, 5u32]];
         let pyarr = arr.to_pyarray(py);
 
@@ -307,7 +307,7 @@ fn dtype_via_python_attribute() {
                 None,
             )
             .unwrap()
-            .downcast_into::<PyArrayDescr>()
+            .cast_into::<PyArrayDescr>()
             .unwrap();
 
         assert!(dt.is_equiv_to(&dtype::<u32>(py)));
@@ -331,7 +331,7 @@ impl Owner {
 
 #[test]
 fn borrow_from_array_works() {
-    let array = Python::with_gil(|py| {
+    let array = Python::attach(|py| {
         let owner = Py::new(
             py,
             Owner {
@@ -343,47 +343,47 @@ fn borrow_from_array_works() {
         owner.getattr(py, "array").unwrap()
     });
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         py_run!(py, array, "assert array.shape == (10,)");
     });
 }
 
 #[test]
-fn downcasting_works() {
-    Python::with_gil(|py| {
+fn casting_works() {
+    Python::attach(|py| {
         let ob = PyArray::from_slice(py, &[1_i32, 2, 3]).into_any();
 
-        assert!(ob.downcast::<PyArray1<i32>>().is_ok());
+        assert!(ob.cast::<PyArray1<i32>>().is_ok());
     });
 }
 
 #[test]
-fn downcasting_respects_element_type() {
-    Python::with_gil(|py| {
+fn casting_respects_element_type() {
+    Python::attach(|py| {
         let ob = PyArray::from_slice(py, &[1_i32, 2, 3]).into_any();
 
-        assert!(ob.downcast::<PyArray1<f64>>().is_err());
+        assert!(ob.cast::<PyArray1<f64>>().is_err());
     });
 }
 
 #[test]
-fn downcasting_respects_dimensionality() {
-    Python::with_gil(|py| {
+fn casting_respects_dimensionality() {
+    Python::attach(|py| {
         let ob = PyArray::from_slice(py, &[1_i32, 2, 3]).into_any();
 
-        assert!(ob.downcast::<PyArray2<i32>>().is_err());
+        assert!(ob.cast::<PyArray2<i32>>().is_err());
     });
 }
 
 #[test]
 fn unbind_works() {
-    let arr: Py<PyArray1<_>> = Python::with_gil(|py| {
+    let arr: Py<PyArray1<_>> = Python::attach(|py| {
         let arr = PyArray::from_slice(py, &[1_i32, 2, 3]);
 
         arr.unbind()
     });
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = arr.bind(py);
 
         assert_eq!(arr.readonly().as_slice().unwrap(), &[1, 2, 3]);
@@ -392,7 +392,7 @@ fn unbind_works() {
 
 #[test]
 fn copy_to_works() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr1 = PyArray::arange(py, 2.0, 5.0, 1.0);
         let arr2 = unsafe { PyArray::<i64, _>::new(py, [3], false) };
 
@@ -404,7 +404,7 @@ fn copy_to_works() {
 
 #[test]
 fn get_works() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = pyarray![py, [[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]];
 
         unsafe {
@@ -423,7 +423,7 @@ fn get_works() {
 
 #[test]
 fn permute_and_transpose() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = array![[0, 1, 2], [3, 4, 5]].into_pyarray(py);
 
         let permuted = array.permute(Some([1, 0])).unwrap();
@@ -456,7 +456,7 @@ fn permute_and_transpose() {
 
 #[test]
 fn reshape() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = PyArray::from_iter(py, 0..9)
             .reshape_with_order([3, 3], NPY_ORDER::NPY_FORTRANORDER)
             .unwrap();
@@ -474,7 +474,7 @@ fn reshape() {
 #[cfg(feature = "half")]
 #[test]
 fn half_f16_works() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let np = py.eval(c_str!("__import__('numpy')"), None, None).unwrap();
         let locals = [("np", &np)].into_py_dict(py).unwrap();
 
@@ -485,7 +485,7 @@ fn half_f16_works() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast_into::<PyArray2<f16>>()
+            .cast_into::<PyArray2<f16>>()
             .unwrap();
 
         assert_eq!(
@@ -512,7 +512,7 @@ fn half_f16_works() {
 #[cfg(feature = "half")]
 #[test]
 fn half_bf16_works() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let np = py.eval(c_str!("__import__('numpy')"), None, None).unwrap();
         // NumPy itself does not provide a `bfloat16` dtype itself,
         // so we import ml_dtypes which does register such a dtype.
@@ -528,7 +528,7 @@ fn half_bf16_works() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast_into::<PyArray2<bf16>>()
+            .cast_into::<PyArray2<bf16>>()
             .unwrap();
 
         assert_eq!(
@@ -554,7 +554,7 @@ fn half_bf16_works() {
 
 #[test]
 fn ascii_strings_with_explicit_dtype_works() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let np = py.eval(c_str!("__import__('numpy')"), None, None).unwrap();
         let locals = [("np", &np)].into_py_dict(py).unwrap();
 
@@ -565,7 +565,7 @@ fn ascii_strings_with_explicit_dtype_works() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast_into::<PyArray1<PyFixedString<6>>>()
+            .cast_into::<PyArray1<PyFixedString<6>>>()
             .unwrap();
 
         {
@@ -590,7 +590,7 @@ fn ascii_strings_with_explicit_dtype_works() {
 
 #[test]
 fn unicode_strings_with_explicit_dtype_works() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let np = py.eval(c_str!("__import__('numpy')"), None, None).unwrap();
         let locals = [("np", &np)].into_py_dict(py).unwrap();
 
@@ -601,7 +601,7 @@ fn unicode_strings_with_explicit_dtype_works() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast_into::<PyArray1<PyFixedUnicode<6>>>()
+            .cast_into::<PyArray1<PyFixedUnicode<6>>>()
             .unwrap();
 
         {
@@ -636,7 +636,7 @@ fn unicode_strings_with_explicit_dtype_works() {
 
 #[test]
 fn ascii_strings_ignore_byteorder() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let np = py.eval(c_str!("__import__('numpy')"), None, None).unwrap();
         let locals = [("np", &np)].into_py_dict(py).unwrap();
 
@@ -647,7 +647,7 @@ fn ascii_strings_ignore_byteorder() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast::<PyArray1<PyFixedString<3>>>()
+            .cast::<PyArray1<PyFixedString<3>>>()
             .is_ok();
 
         let little_endian_works = py
@@ -657,7 +657,7 @@ fn ascii_strings_ignore_byteorder() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast::<PyArray1<PyFixedString<3>>>()
+            .cast::<PyArray1<PyFixedString<3>>>()
             .is_ok();
 
         let big_endian_works = py
@@ -667,7 +667,7 @@ fn ascii_strings_ignore_byteorder() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast::<PyArray1<PyFixedString<3>>>()
+            .cast::<PyArray1<PyFixedString<3>>>()
             .is_ok();
 
         match (native_endian_works, little_endian_works, big_endian_works) {
@@ -679,7 +679,7 @@ fn ascii_strings_ignore_byteorder() {
 
 #[test]
 fn unicode_strings_respect_byteorder() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let np = py.eval(c_str!("__import__('numpy')"), None, None).unwrap();
         let locals = [("np", &np)].into_py_dict(py).unwrap();
 
@@ -690,7 +690,7 @@ fn unicode_strings_respect_byteorder() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast::<PyArray1<PyFixedUnicode<3>>>()
+            .cast::<PyArray1<PyFixedUnicode<3>>>()
             .is_ok();
 
         let little_endian_works = py
@@ -700,7 +700,7 @@ fn unicode_strings_respect_byteorder() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast::<PyArray1<PyFixedUnicode<3>>>()
+            .cast::<PyArray1<PyFixedUnicode<3>>>()
             .is_ok();
 
         let big_endian_works = py
@@ -710,7 +710,7 @@ fn unicode_strings_respect_byteorder() {
                 Some(&locals),
             )
             .unwrap()
-            .downcast::<PyArray1<PyFixedUnicode<3>>>()
+            .cast::<PyArray1<PyFixedUnicode<3>>>()
             .is_ok();
 
         match (native_endian_works, little_endian_works, big_endian_works) {

--- a/tests/array_like.rs
+++ b/tests/array_like.rs
@@ -14,7 +14,7 @@ fn get_np_locals(py: Python<'_>) -> Bound<'_, PyDict> {
 
 #[test]
 fn extract_reference() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let locals = get_np_locals(py);
         let py_array = py
             .eval(
@@ -34,7 +34,7 @@ fn extract_reference() {
 
 #[test]
 fn convert_array_on_extract() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let locals = get_np_locals(py);
         let py_array = py
             .eval(
@@ -56,7 +56,7 @@ fn convert_array_on_extract() {
 
 #[test]
 fn convert_list_on_extract() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_list = py
             .eval(c_str!("[[1.0,2.0],[3.0,4.0]]"), None, None)
             .unwrap();
@@ -68,7 +68,7 @@ fn convert_list_on_extract() {
 
 #[test]
 fn convert_array_in_list_on_extract() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let locals = get_np_locals(py);
         let py_array = py
             .eval(
@@ -85,7 +85,7 @@ fn convert_array_in_list_on_extract() {
 
 #[test]
 fn convert_list_on_extract_dyn() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_list = py
             .eval(c_str!("[[[1,2],[3,4]],[[5,6],[7,8]]]"), None, None)
             .unwrap();
@@ -102,7 +102,7 @@ fn convert_list_on_extract_dyn() {
 
 #[test]
 fn convert_1d_list_on_extract() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_list = py.eval(c_str!("[1,2,3,4]"), None, None).unwrap();
         let extracted_array_1d = py_list.extract::<PyArrayLike1<'_, u32>>().unwrap();
         let extracted_array_dyn = py_list.extract::<PyArrayLikeDyn<'_, f64>>().unwrap();
@@ -117,7 +117,7 @@ fn convert_1d_list_on_extract() {
 
 #[test]
 fn unsafe_cast_shall_fail() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let locals = get_np_locals(py);
         let py_list = py
             .eval(
@@ -134,7 +134,7 @@ fn unsafe_cast_shall_fail() {
 
 #[test]
 fn unsafe_cast_with_coerce_works() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let locals = get_np_locals(py);
         let py_list = py
             .eval(

--- a/tests/sum_products.rs
+++ b/tests/sum_products.rs
@@ -4,7 +4,7 @@ use pyo3::{Bound, Python};
 
 #[test]
 fn test_dot() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let a = pyarray![py, [1, 0], [0, 1]];
         let b = pyarray![py, [4, 1], [2, 2]];
         let c: Bound<'_, PyArray2<_>> = dot(&a, &b).unwrap();
@@ -30,7 +30,7 @@ fn test_dot() {
 
 #[test]
 fn test_inner() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let a = pyarray![py, 1, 2, 3];
         let b = pyarray![py, 0, 1, 0];
         let c: Bound<'_, PyArray0<_>> = inner(&a, &b).unwrap();
@@ -56,7 +56,7 @@ fn test_inner() {
 
 #[test]
 fn test_einsum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let a = PyArray1::<i32>::arange(py, 0, 25, 1)
             .reshape([5, 5])
             .unwrap();

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -11,7 +11,7 @@ use pyo3::{
 
 #[test]
 fn to_pyarray_vec() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         #[allow(clippy::useless_vec)]
         let arr = vec![1, 2, 3].to_pyarray(py);
 
@@ -22,7 +22,7 @@ fn to_pyarray_vec() {
 
 #[test]
 fn to_pyarray_boxed_slice() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = vec![1, 2, 3].into_boxed_slice().to_pyarray(py);
 
         assert_eq!(arr.shape(), [3]);
@@ -32,7 +32,7 @@ fn to_pyarray_boxed_slice() {
 
 #[test]
 fn to_pyarray_array() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = Array3::<f64>::zeros((3, 4, 2));
 
         let shape = arr.shape().to_vec();
@@ -51,7 +51,7 @@ fn to_pyarray_array() {
 
 #[test]
 fn iter_to_pyarray() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = PyArray::from_iter(py, (0..10).map(|x| x * x));
 
         assert_eq!(
@@ -63,7 +63,7 @@ fn iter_to_pyarray() {
 
 #[test]
 fn long_iter_to_pyarray() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = PyArray::from_iter(py, 0_u32..512);
 
         assert_eq!(
@@ -78,7 +78,7 @@ fn from_small_array() {
     macro_rules! small_array_test {
         ($($t:ty)+) => {
             $({
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let array: [$t; 2] = [<$t>::MIN, <$t>::MAX];
                     let pyarray = array.to_pyarray(py);
 
@@ -96,7 +96,7 @@ fn from_small_array() {
 
 #[test]
 fn usize_dtype() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let x = vec![1_usize, 2, 3].into_pyarray(py);
 
         if cfg!(target_pointer_width = "64") {
@@ -109,7 +109,7 @@ fn usize_dtype() {
 
 #[test]
 fn into_pyarray_vec() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = vec![1, 2, 3].into_pyarray(py);
 
         assert_eq!(arr.readonly().as_slice().unwrap(), &[1, 2, 3])
@@ -118,7 +118,7 @@ fn into_pyarray_vec() {
 
 #[test]
 fn into_pyarray_boxed_slice() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = vec![1, 2, 3].into_boxed_slice().into_pyarray(py);
 
         assert_eq!(arr.readonly().as_slice().unwrap(), &[1, 2, 3])
@@ -127,7 +127,7 @@ fn into_pyarray_boxed_slice() {
 
 #[test]
 fn into_pyarray_array() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = Array3::<f64>::zeros((3, 4, 2));
 
         let shape = arr.shape().to_vec();
@@ -146,7 +146,7 @@ fn into_pyarray_array() {
 
 #[test]
 fn into_pyarray_cannot_resize() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = vec![1, 2, 3].into_pyarray(py);
 
         unsafe {
@@ -157,7 +157,7 @@ fn into_pyarray_cannot_resize() {
 
 #[test]
 fn into_pyarray_can_write() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let arr = vec![1, 2, 3].into_pyarray(py);
 
         py_run!(py, arr, "assert arr.flags['WRITEABLE']");
@@ -170,7 +170,7 @@ fn collapsed_into_pyarray() {
     // Check that `into_pyarray` works for array with the pointer of the first element is
     // not at the start of the allocation.
     // See https://github.com/PyO3/rust-numpy/issues/182 for more.
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut arr = Array2::<f64>::from_shape_fn([3, 4], |(i, j)| (i * 10 + j) as f64);
         arr.slice_collapse(s![1.., ..]);
         let cloned_arr = arr.clone();
@@ -183,7 +183,7 @@ fn collapsed_into_pyarray() {
 
 #[test]
 fn sliced_to_pyarray() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let matrix = Array2::from_shape_vec([4, 2], vec![0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
         let sliced_matrix = matrix.slice(s![1..4; -1, ..]);
 
@@ -197,7 +197,7 @@ fn sliced_to_pyarray() {
 
 #[test]
 fn forder_to_pyarray() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let matrix = Array2::from_shape_vec([4, 2], vec![0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
         let forder_matrix = matrix.reversed_axes();
 
@@ -214,7 +214,7 @@ fn forder_to_pyarray() {
 
 #[test]
 fn forder_into_pyarray() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let matrix = Array2::from_shape_vec([4, 2], vec![0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
         let forder_matrix = matrix.reversed_axes();
 
@@ -231,7 +231,7 @@ fn forder_into_pyarray() {
 
 #[test]
 fn to_pyarray_object_vec() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = PyDict::new(py);
         let string = PyString::new(py, "Hello:)");
         #[allow(clippy::useless_vec)] // otherwise we do not test the right trait impl
@@ -250,7 +250,7 @@ fn to_pyarray_object_vec() {
 
 #[test]
 fn to_pyarray_object_array() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut nd_arr = Array2::from_shape_fn((2, 3), |(_, _)| py.None());
         nd_arr[(0, 2)] = PyDict::new(py).into_any().unbind();
         nd_arr[(1, 0)] = PyString::new(py, "Hello:)").into_any().unbind();
@@ -273,7 +273,7 @@ fn to_pyarray_object_array() {
 
 #[test]
 fn slice_container_type_confusion() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut nd_arr = Array2::from_shape_fn((2, 3), |(_, _)| py.None());
         nd_arr[(0, 2)] = PyDict::new(py).into_any().unbind();
         nd_arr[(1, 0)] = PyString::new(py, "Hello:)").into_any().unbind();
@@ -294,7 +294,7 @@ fn matrix_to_numpy() {
     let matrix = nalgebra::Matrix3::<i32>::new(0, 1, 2, 3, 4, 5, 6, 7, 8);
     assert!(nalgebra::RawStorage::is_contiguous(&matrix.data));
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = matrix.to_pyarray(py);
 
         assert_eq!(
@@ -306,7 +306,7 @@ fn matrix_to_numpy() {
     let matrix = matrix.row(0);
     assert!(!nalgebra::RawStorage::is_contiguous(&matrix.data));
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = matrix.to_pyarray(py);
 
         assert_eq!(array.readonly().as_array(), array![[0, 1, 2]]);
@@ -314,7 +314,7 @@ fn matrix_to_numpy() {
 
     let vector = nalgebra::Vector4::<i32>::new(-4, 1, 2, 3);
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = vector.to_pyarray(py);
 
         assert_eq!(array.readonly().as_array(), array![[-4], [1], [2], [3]]);
@@ -322,7 +322,7 @@ fn matrix_to_numpy() {
 
     let vector = nalgebra::RowVector2::<i32>::new(23, 42);
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let array = vector.to_pyarray(py);
 
         assert_eq!(array.readonly().as_array(), array![[23, 42]]);


### PR DESCRIPTION
Upgrades to PyO3 0.26

- rename `with_gil`/`allow_threads` -> `attach`/`detach`
- use `cast` instead of `downcast`
- replace `PyObject` by `Py<PyAny>`
- replace `GILOnceCell` by `PyOnceLock`
- introduce `PyArrayMethods::cast_array` and deprecate `PyArrayMethods::cast` because it clashes now with `Bound::cast`