### PR TITLE
Exclude some unnecessary files from the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ repository = "https://github.com/PyO3/rust-numpy"
 categories = ["api-bindings", "development-tools::ffi", "science"]
 keywords = ["python", "numpy", "ffi", "pyo3"]
 license = "BSD-2-Clause"
+exclude = [
+    ".github/*",
+    ".gitignore",
+    "codecov.yml",
+    "x.py",
+]
 
 [dependencies]
 half = { version = "2.0", default-features = false, optional = true }


### PR DESCRIPTION
Exclude from the published crate the contents of `.github/` (CI workflows, etc.) and other files that are only useful for upstream development, not for crate users (`.gitignore`, `codecov.yml`, `x.py`). This slightly slims down the crate.

This is also helpful downstream, e.g. in Fedora, where a proposed `rust-numpy-devel` package would have an automatically-generated dependency on `/usr/bin/python3` if `x.py` is not excluded.

For now, tests and benchmarks are both still included in the published crate.