### PR TITLE
remove deprecated `extension-module` feature from docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27", features = ["extension-module"] }
+pyo3 = { version = "0.27" }
 numpy = "0.27"
 ```
 

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_linalg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.0", features = ["extension-module"] }
+pyo3 = { version = "0.27.0" }
 numpy = { path = "../.." }
 ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
 

--- a/examples/linalg/pyproject.toml
+++ b/examples/linalg/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 build-backend = "maturin"
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_parallel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.0", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.27.0", features = ["multiple-pymethods"] }
 numpy = { path = "../.." }
 ndarray = { version = "0.17", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }

--- a/examples/parallel/pyproject.toml
+++ b/examples/parallel/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 build-backend = "maturin"
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.0", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.27.0", features = ["abi3-py37"] }
 numpy = { path = "../.." }
 
 [workspace]

--- a/examples/simple/pyproject.toml
+++ b/examples/simple/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 build-backend = "maturin"
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]


### PR DESCRIPTION
Removes the deprecated (and now unneeded) `extension-module` feature from docs and examples.

See https://pyo3.rs/main/building-and-distribution#the-pyo3_build_extension_module-environment-variable
Ref: https://github.com/PyO3/pyo3/pull/5588