### PR TITLE
ndarray version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nalgebra = { version = ">=0.30, <0.35", default-features = false, optional = tru
 num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
-ndarray = ">= 0.15, <=0.17"
+ndarray = ">= 0.15, <=0.17.*"
 pyo3 = { version = "0.27.0", default-features = false, features = ["macros"] }
 rustc-hash = "2.0"
 


### PR DESCRIPTION
Modifed the requirements for the `ndarray` crate.
Added ``.*`` for the patch version.
Allows use with the most up to date version of ``ndarray``