### PR TITLE
Upgrade PyO3 from 0.27 to 0.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.74
+        uses: dtolnay/rust-toolchain@1.83
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: examples/simple

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 description = "PyO3-based Rust bindings of the NumPy C-API"
 documentation = "https://docs.rs/numpy"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.83"
 repository = "https://github.com/PyO3/rust-numpy"
 categories = ["api-bindings", "development-tools::ffi", "science"]
 keywords = ["python", "numpy", "ffi", "pyo3"]
@@ -28,15 +28,15 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, <=0.17"
-pyo3 = { version = "0.27.0", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.28.0", default-features = false, features = ["macros"] }
 rustc-hash = "2.0"
 
 [dev-dependencies]
-pyo3 = { version = "0.27.0", default-features = false, features = ["auto-initialize"]}
+pyo3 = { version = "0.28.0", default-features = false, features = ["auto-initialize"]}
 nalgebra = { version = ">=0.30, <0.35", default-features = false, features = ["std"] }
 
 [build-dependencies]
-pyo3-build-config = { version = "0.27", features = ["resolve-config"]}
+pyo3-build-config = { version = "0.28", features = ["resolve-config"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ rust-numpy
 ===========
 [![Actions Status](https://github.com/PyO3/rust-numpy/workflows/CI/badge.svg)](https://github.com/PyO3/rust-numpy/actions)
 [![Crate](https://img.shields.io/crates/v/numpy.svg)](https://crates.io/crates/numpy)
-[![Minimum rustc 1.74](https://img.shields.io/badge/rustc-1.74+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Minimum rustc 1.83](https://img.shields.io/badge/rustc-1.83+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Documentation](https://docs.rs/numpy/badge.svg)](https://docs.rs/numpy)
 [![codecov](https://codecov.io/gh/PyO3/rust-numpy/branch/main/graph/badge.svg)](https://codecov.io/gh/PyO3/rust-numpy)
 
@@ -13,7 +13,7 @@ Rust bindings for the NumPy C-API.
 - [Current main](https://pyo3.github.io/rust-numpy)
 
 ## Requirements
-- Rust >= 1.74.0
+- Rust >= 1.83.0
   - Basically, our MSRV follows the one of [PyO3](https://github.com/PyO3/pyo3)
 - Python >= 3.7
   - Python 3.6 support was dropped from 0.16

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_linalg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.0" }
+pyo3 = { version = "0.28.0" }
 numpy = { path = "../.." }
 ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
 

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_parallel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.0", features = ["multiple-pymethods"] }
+pyo3 = { version = "0.28.0", features = ["multiple-pymethods"] }
 numpy = { path = "../.." }
 ndarray = { version = "0.17", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.0", features = ["abi3-py37"] }
+pyo3 = { version = "0.28.0", features = ["abi3-py37"] }
 numpy = { path = "../.." }
 
 [workspace]


### PR DESCRIPTION
Bump pyo3 to 0.28.0, pyo3-build-config to 0.28, and MSRV to 1.83 across the main crate and all examples.