### PR TITLE
Fix PyArray_DTypeMeta definition when Py_LIMITED_API is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+- Unreleased
+  - Fix PyArray_DTypeMeta definition when Py_LIMITED_API is disabled (#532)
+
 - v0.28.0
   - Fix mismatched behavior between `PyArrayLike1` and `PyArrayLike2` when used with floats ([#520](https://github.com/PyO3/rust-numpy/pull/520))
   - Add ownership-moving conversions into `PyReadonlyArray` and `PyReadwriteArray` ([#524](https://github.com/PyO3/rust-numpy/pull/524))

--- a/src/npyffi/objects.rs
+++ b/src/npyffi/objects.rs
@@ -549,6 +549,20 @@ pub struct PyArray_DatetimeDTypeMetaData {
 // https://github.com/rust-lang/rust/issues/43467
 pub type npy_packed_static_string = c_void;
 pub type npy_string_allocator = c_void;
+
+#[cfg(not(Py_LIMITED_API))]
+#[repr(C)]
+pub struct PyArray_DTypeMeta {
+    pub superclass: PyHeapTypeObject,
+    pub singleton: *mut PyArray_Descr,
+    pub type_num: c_int,
+    pub scalar_type: *mut PyTypeObject,
+    pub flags: npy_uint64,
+    pub dt_slots: *mut c_void,
+    pub reserved: [*mut c_void; 3],
+}
+
+#[cfg(Py_LIMITED_API)]
 pub type PyArray_DTypeMeta = PyTypeObject;
 
 #[repr(C)]


### PR DESCRIPTION
When `Py_LIMITED_API` is disabled, `PyArray_DTypeMeta` has a different memory layout than `PyTypeObject`. This is explicitly documented in the [NumPy C-API reference](https://numpy.org/doc/2.0/reference/c-api/array.html#c.PyArrayInitDTypeMeta_FromSpec), which states that `PyArray_DTypeMeta` contains additional fields beyond those in `PyTypeObject`.

This structure is confirmed by the [header file definition](https://github.com/numpy/numpy/blob/v2.4.2/numpy/_core/include/numpy/dtype_api.h#L18-L57).