### PR TITLE
fix: implement is_exact_type_of to check dtype and shape for PyArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Unreleased
   - Fix PyArray_DTypeMeta definition when Py_LIMITED_API is disabled ([#532](https://github.com/PyO3/rust-numpy/pull/532))
   - The NumPy C API binding has been updated to target the ABI v2, while maintaining runtime compatibility with NumPy v1 targeting the API v1.15. The higher interface is unchanged. ([#537](https://github.com/PyO3/rust-numpy/pull/537))
+  - Fix `is_exact_type_of` / `cast_exact` to use `PyArray_CheckExact` instead of `PyArray_Check`, correctly rejecting subclasses of `ndarray`. ([#550](https://github.com/PyO3/rust-numpy/pull/550))
 
 - v0.28.0
   - Fix mismatched behavior between `PyArrayLike1` and `PyArrayLike2` when used with floats ([#520](https://github.com/PyO3/rust-numpy/pull/520))

--- a/src/array.rs
+++ b/src/array.rs
@@ -134,6 +134,10 @@ unsafe impl<T: Element, D: Dimension> PyTypeInfo for PyArray<T, D> {
     fn is_type_of(ob: &Bound<'_, PyAny>) -> bool {
         Self::extract::<IgnoreError>(ob).is_ok()
     }
+
+    fn is_exact_type_of(ob: &Bound<'_, PyAny>) -> bool {
+        Self::extract::<IgnoreError>(ob).is_ok()
+    }
 }
 
 impl<T: Element, D: Dimension> PyArray<T, D> {

--- a/src/array.rs
+++ b/src/array.rs
@@ -132,22 +132,25 @@ unsafe impl<T: Element, D: Dimension> PyTypeInfo for PyArray<T, D> {
     }
 
     fn is_type_of(ob: &Bound<'_, PyAny>) -> bool {
-        Self::extract::<IgnoreError>(ob).is_ok()
+        Self::extract::<IgnoreError>(ob, npyffi::PyArray_Check).is_ok()
     }
 
     fn is_exact_type_of(ob: &Bound<'_, PyAny>) -> bool {
-        Self::extract::<IgnoreError>(ob).is_ok()
+        Self::extract::<IgnoreError>(ob, npyffi::PyArray_CheckExact).is_ok()
     }
 }
 
 impl<T: Element, D: Dimension> PyArray<T, D> {
-    fn extract<'a, 'py, E>(ob: &'a Bound<'py, PyAny>) -> Result<&'a Bound<'py, Self>, E>
+    fn extract<'a, 'py, E>(
+        ob: &'a Bound<'py, PyAny>,
+        check: unsafe fn(Python<'py>, *mut ffi::PyObject) -> c_int,
+    ) -> Result<&'a Bound<'py, Self>, E>
     where
         E: From<CastError<'a, 'py>> + From<DimensionalityError> + From<TypeError<'py>>,
     {
         // Check if the object is an array.
         let array = unsafe {
-            if npyffi::PyArray_Check(ob.py(), ob.as_ptr()) == 0 {
+            if check(ob.py(), ob.as_ptr()) == 0 {
                 return Err(CastError::new(
                     ob.as_borrowed(),
                     <Self as PyTypeCheck>::classinfo_object(ob.py()),

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -268,6 +268,19 @@ fn cast_exact_checks_dtype_and_shape() {
 
         // cast_exact should fail when dimensionality does not match
         assert!(arr_f64_3d.as_any().cast_exact::<PyArray2<f64>>().is_err());
+
+        // cast_exact should reject subclasses of ndarray; cast should accept them
+        let masked = py
+            .eval(
+                pyo3::ffi::c_str!(
+                    "__import__('numpy').ma.MaskedArray([[1.0, 2.0], [3.0, 4.0]], dtype='float64')"
+                ),
+                None,
+                None,
+            )
+            .unwrap();
+        assert!(masked.cast::<PyArray2<f64>>().is_ok());
+        assert!(masked.cast_exact::<PyArray2<f64>>().is_err());
     });
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -252,6 +252,26 @@ fn is_instance() {
 }
 
 #[test]
+fn cast_exact_checks_dtype_and_shape() {
+    Python::attach(|py| {
+        let arr_f64 = PyArray2::<f64>::zeros(py, [3, 5], false);
+        let arr_f32 = PyArray2::<f32>::zeros(py, [3, 5], false);
+        let arr_f64_3d = PyArray::<f64, _>::zeros(py, [3, 5, 7], false);
+
+        // cast_exact should succeed when dtype and shape both match
+        assert!(arr_f64.as_any().cast_exact::<PyArray2<f64>>().is_ok());
+        assert!(arr_f32.as_any().cast_exact::<PyArray2<f32>>().is_ok());
+
+        // cast_exact should fail when dtype does not match
+        assert!(arr_f64.as_any().cast_exact::<PyArray2<f32>>().is_err());
+        assert!(arr_f32.as_any().cast_exact::<PyArray2<f64>>().is_err());
+
+        // cast_exact should fail when dimensionality does not match
+        assert!(arr_f64_3d.as_any().cast_exact::<PyArray2<f64>>().is_err());
+    });
+}
+
+#[test]
 fn from_vec2() {
     Python::attach(|py| {
         let pyarray = PyArray::from_vec2(py, &[vec![1, 2, 3], vec![4, 5, 6]]).unwrap();


### PR DESCRIPTION
## Problem

  `PyTypeInfo::is_exact_type_of` was not overridden for `PyArray<T, D>`, so the
  default PyO3 implementation (a plain Python type object pointer comparison) was
  used. This caused `cast_exact` and `downcast_exact` to ignore element dtype and
  array dimensionality — a float32 array would silently pass a `cast_exact::<PyArray2<f64>>()` check.

  Reported in #549, also related to #547.

  ## Fix

  Override `is_exact_type_of` with the same implementation as `is_type_of`, which
  calls `Self::extract` internally. This checks:
  1. That the object is a NumPy array
  2. That the dimensionality matches `D`
  3. That the element dtype matches `T`

  ## Test

  Added `cast_exact_checks_dtype_and_shape` to `tests/array.rs` which verifies:
  - `cast_exact` succeeds when both dtype and shape match
  - `cast_exact` fails when dtype does not match
  - `cast_exact` fails when dimensionality does not match
