### PR TITLE
Updated to PyO3 version 0.29.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,12 @@ jobs:
       matrix:
         python-version:
           [
-            "3.7",
             "3.8",
             "3.9",
             "3.10",
             "3.11",
             "3.12",
             "3.13",
-            "3.13t",
             "3.14",
             "3.14t",
             "pypy-3.11",
@@ -68,23 +66,11 @@ jobs:
             },
           ]
         include:
-          # ubuntu-24.04 does not support 3.7
-          - python-version: 3.7
-            platform: { os: "ubuntu-22.04", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
-          # not available on arm64 macOS, test on x64
-          - python-version: 3.7
-            platform: { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin" }
           - python-version: 3.8
             platform: { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin" }
           - python-version: 3.9
             platform: { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin" }
         exclude:
-          # ubuntu-24.04 does not support 3.7
-          - python-version: 3.7
-            platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
-          # not available on arm64 macOS
-          - python-version: 3.7
-            platform: { os: "macOS-latest", python-architecture: "arm64", rust-target: "aarch64-apple-darwin" }
           - python-version: 3.8
             platform: { os: "macOS-latest", python-architecture: "arm64", rust-target: "aarch64-apple-darwin" }
           - python-version: 3.9
@@ -125,7 +111,7 @@ jobs:
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"] # last numpy 1 release for 3.12
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"] # last numpy 1 release for 3.12
         platform:
           [
             {
@@ -150,23 +136,11 @@ jobs:
             },
           ]
         include:
-          # ubuntu-24.04 does not support 3.7
-          - python-version: 3.7
-            platform: { os: "ubuntu-22.04", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
-          # not available on arm64 macOS, test on x64
-          - python-version: 3.7
-            platform: { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin" }
           - python-version: 3.8
             platform: { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin" }
           - python-version: 3.9
             platform: { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin" }
         exclude:
-          # ubuntu-24.04 does not support 3.7
-          - python-version: 3.7
-            platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
-          # not available on arm64 macOS
-          - python-version: 3.7
-            platform: { os: "macOS-latest", python-architecture: "arm64", rust-target: "aarch64-apple-darwin" }
           - python-version: 3.8
             platform: { os: "macOS-latest", python-architecture: "arm64", rust-target: "aarch64-apple-darwin" }
           - python-version: 3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
 - Unreleased
+
+- v0.29.0
   - Fix PyArray_DTypeMeta definition when Py_LIMITED_API is disabled ([#532](https://github.com/PyO3/rust-numpy/pull/532))
   - The NumPy C API binding has been updated to target the ABI v2, while maintaining runtime compatibility with NumPy v1 targeting the API v1.15. The higher interface is unchanged. ([#537](https://github.com/PyO3/rust-numpy/pull/537))
   - Fix `is_exact_type_of` / `cast_exact` to use `PyArray_CheckExact` instead of `PyArray_Check`, correctly rejecting subclasses of `ndarray`. ([#550](https://github.com/PyO3/rust-numpy/pull/550))
-  - Bump PyO3 dependency to v0.29.0. Fix `PyCapsule::new_with_destructor` to use `PyCapsule::new_with_value_and_destructor`. ([#553](https://github.com/PyO3/rust-numpy/pull/553))
+  - Bump PyO3 dependency to v0.29.0 ([#553](https://github.com/PyO3/rust-numpy/pull/553))
+    - Fix `PyCapsule::new_with_destructor` to use `PyCapsule::new_with_value_and_destructor`. 
+    - Open `nalgebra` range to include 0.35.
 
 - v0.28.0
   - Fix mismatched behavior between `PyArrayLike1` and `PyArrayLike2` when used with floats ([#520](https://github.com/PyO3/rust-numpy/pull/520))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Fix PyArray_DTypeMeta definition when Py_LIMITED_API is disabled ([#532](https://github.com/PyO3/rust-numpy/pull/532))
   - The NumPy C API binding has been updated to target the ABI v2, while maintaining runtime compatibility with NumPy v1 targeting the API v1.15. The higher interface is unchanged. ([#537](https://github.com/PyO3/rust-numpy/pull/537))
   - Fix `is_exact_type_of` / `cast_exact` to use `PyArray_CheckExact` instead of `PyArray_Check`, correctly rejecting subclasses of `ndarray`. ([#550](https://github.com/PyO3/rust-numpy/pull/550))
+  - Bump PyO3 dependency to v0.29.0. Fix `PyCapsule::new_with_destructor` to use `PyCapsule::new_with_value_and_destructor`. ([#553](https://github.com/PyO3/rust-numpy/pull/553))
 
 - v0.28.0
   - Fix mismatched behavior between `PyArrayLike1` and `PyArrayLike2` when used with floats ([#520](https://github.com/PyO3/rust-numpy/pull/520))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.28.0"
+version = "0.29.0"
 authors = [
     "The rust-numpy Project Developers",
     "PyO3 Project and Contributors <https://github.com/PyO3>",
@@ -28,16 +28,16 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.15, <=0.17"
-pyo3 = { version = "0.28.0", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.29.0", default-features = false, features = ["macros"] }
 rustc-hash = "2.0"
 
 [dev-dependencies]
-pyo3 = { version = "0.28.0", default-features = false, features = ["auto-initialize"]}
+pyo3 = { version = "0.29.0", default-features = false, features = ["auto-initialize"]}
 nalgebra = { version = ">=0.30, <0.35", default-features = false, features = ["std"] }
 criterion = "0.8.2"
 
 [build-dependencies]
-pyo3-build-config = { version = "0.28", features = ["resolve-config"]}
+pyo3-build-config = { version = "0.29", features = ["resolve-config"]}
 
 [[bench]]
 name = "array"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 [dependencies]
 half = { version = "2.0", default-features = false, optional = true }
 libc = "0.2"
-nalgebra = { version = ">=0.30, <0.35", default-features = false, optional = true }
+nalgebra = { version = ">=0.30, <=0.35", default-features = false, optional = true }
 num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Rust bindings for the NumPy C-API.
 ## Requirements
 - Rust >= 1.83.0
   - Basically, our MSRV follows the one of [PyO3](https://github.com/PyO3/pyo3)
-- Python >= 3.7
-  - Python 3.6 support was dropped from 0.16
+- Python >= 3.8
+  - Python 3.7 support was dropped from 0.29
 - Some Rust libraries
   - [ndarray](https://github.com/rust-ndarray/ndarray) for Rust-side matrix library
   - [PyO3](https://github.com/PyO3/pyo3) for Python bindings
@@ -38,8 +38,8 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27" }
-numpy = "0.27"
+pyo3 = { version = "0.29" }
+numpy = "0.29"
 ```
 
 ```rust
@@ -89,8 +89,8 @@ mod rust_ext {
 name = "numpy-test"
 
 [dependencies]
-pyo3 = { version = "0.27", features = ["auto-initialize"] }
-numpy = "0.27"
+pyo3 = { version = "0.29", features = ["auto-initialize"] }
+numpy = "0.29"
 ```
 
 ```rust
@@ -128,7 +128,7 @@ on anything but that exact range. It can therefore be necessary to manually unif
 For example, if you specify the following dependencies
 
 ```toml
-numpy = "0.27"
+numpy = "0.29"
 ndarray = "0.15"
 ```
 

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_linalg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28.0" }
+pyo3 = { version = "0.29.0" }
 numpy = { path = "../.." }
 ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
 

--- a/examples/parallel/Cargo.toml
+++ b/examples/parallel/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_parallel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28.0", features = ["multiple-pymethods"] }
+pyo3 = { version = "0.29.0", features = ["multiple-pymethods"] }
 numpy = { path = "../.." }
 ndarray = { version = "0.17", features = ["rayon", "blas"] }
 blas-src = { version = "0.8", features = ["openblas"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28.0", features = ["abi3-py37"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py38"] }
 numpy = { path = "../.." }
 
 [workspace]

--- a/src/borrow/shared.rs
+++ b/src/borrow/shared.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::ffi::{c_char, c_int, c_void, CString};
+use std::ffi::{c_char, c_int, c_void};
 use std::mem::forget;
 use std::ptr::NonNull;
 use std::slice::from_raw_parts;
@@ -135,10 +135,10 @@ fn insert_shared<'py>(py: Python<'py>) -> PyResult<NonNull<Shared>> {
                 release_mut: release_mut_shared,
             };
 
-            let capsule = PyCapsule::new_with_destructor(
+            let capsule = PyCapsule::new_with_value_and_destructor(
                 py,
                 shared,
-                Some(CString::new("_RUST_NUMPY_BORROW_CHECKING_API").unwrap()),
+                c"_RUST_NUMPY_BORROW_CHECKING_API",
                 |shared, _ctx| {
                     // SAFETY: `shared.flags` was initialized using `Box::into_raw`.
                     let _ = unsafe { Box::from_raw(shared.flags as *mut BorrowFlags) };


### PR DESCRIPTION
- Updated PyO3 version
- fixed deprecation (hope that is correct)
- updated README and examples (some were stuck in 0.27)

I would like to add a bump of `nalgebra` to 0.35 (has `rust-version = "1.89.0"`). Let me know if this is suitable for this PR as well.