### PR TITLE
add support for abi3t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   test:
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }}
     runs-on: ${{ matrix.platform.os }}
+    continue-on-error: ${{ startsWith(matrix.python-version, '3.15') }} # remove once 3.15 releases
     needs: [lint, check-msrv, examples]
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
@@ -40,6 +41,8 @@ jobs:
             "3.13",
             "3.14",
             "3.14t",
+            "3.15",
+            "3.15t",
             "pypy-3.11",
           ]
         platform:
@@ -78,6 +81,10 @@ jobs:
           # no 32 bit windows PyPy
           - python-version: pypy-3.11
             platform: { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" }
+          # free-threaded on 32bit only supported on 3.15+
+          - python-version: 3.14t
+            platform: { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" }
+
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -85,24 +92,35 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
+          allow-prereleases: ${{ startsWith(matrix.python-version, '3.15') }} # remove once 3.15 releases
+      - name: Set up UV
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform.rust-target }}
       - name: Test
-        run: |
-          pip install "numpy" ml_dtypes
-          cargo test --all-features
         # Not on PyPy, because no embedding API
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
+        run: |
+          uv pip install "numpy" ml_dtypes
+          cargo test --all-features
+      - name: Test abi3t
+        if: ${{ matrix.python-version == '3.15t' }}
+        run: |
+          cargo test --all-features -F pyo3/abi3t
       - name: Test example
         run: |
-          pip install nox
-          nox -f examples/simple/noxfile.py
+          uvx nox -f examples/simple/noxfile.py
     env:
       CARGO_TERM_VERBOSE: true
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
       RUST_BACKTRACE: 1
+      UV_SYSTEM_PYTHON: true
+      UV_PRERELEASE: ${{ startsWith(matrix.python-version, '3.15') && 'allow' || 'disallow' }} # remove once numpy 2.6 releases
+      UV_NO_BUILD_PACKAGE: "numpy"
+      UV_INDEX: ${{ startsWith(matrix.python-version, '3.15') && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/' || '' }} # remove once numpy 2.6 releases
+      NOX_DEFAULT_VENV_BACKEND: "uv"
 
   test-numpy1:
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} numpy1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           uv pip install "numpy" ml_dtypes
           cargo test --all-features
       - name: Test abi3t
-        if: ${{ matrix.python-version == '3.15t' }}
+        if: ${{ endsWith(matrix.python-version, 't') }}
         run: |
           cargo test --all-features -F pyo3/abi3t
       - name: Test example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,6 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
       RUST_BACKTRACE: 1
       UV_SYSTEM_PYTHON: true
-      UV_PRERELEASE: ${{ startsWith(matrix.python-version, '3.15') && 'allow' || 'disallow' }} # remove once numpy 2.6 releases
-      UV_NO_BUILD_PACKAGE: "numpy"
-      UV_INDEX: ${{ startsWith(matrix.python-version, '3.15') && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/' || '' }} # remove once numpy 2.6 releases
       NOX_DEFAULT_VENV_BACKEND: "uv"
 
   test-numpy1:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Unreleased
   - `PyReadonlyArray`/`PyReadwriteArray` extraction now returns a `PyErr` which reports the actual dtype/dimensionality mismatch instead of nonsensical `CastError` messages like “'ndarray' is not an instance of 'ndarray'” ([#562](https://github.com/PyO3/rust-numpy/pull/562))
+  - Add support for free-threaded stable abi (abi3t) from Python 3.15t+ ([#556](https://github.com/PyO3/rust-numpy/pull/556))
+  - fixed free-threaded builds for 32 bit platforms from Python 3.15+ ([#556](https://github.com/PyO3/rust-numpy/pull/556))
 
 - v0.29.0
   - Fix PyArray_DTypeMeta definition when Py_LIMITED_API is disabled ([#532](https://github.com/PyO3/rust-numpy/pull/532))

--- a/src/array.rs
+++ b/src/array.rs
@@ -28,7 +28,7 @@ use crate::error::{
     AsSliceError, BorrowError, DimensionalityError, FromVecError, IgnoreError, TypeError,
     DIMENSIONALITY_MISMATCH_ERR, MAX_DIMENSIONALITY_ERR,
 };
-use crate::npyffi::{self, npy_intp, NPY_ORDER, PY_ARRAY_API};
+use crate::npyffi::{self, _PyArray_GET_ITEM_DATA, npy_intp, NPY_ORDER, PY_ARRAY_API};
 use crate::slice_container::PySliceContainer;
 use crate::untyped_array::{PyUntypedArray, PyUntypedArrayMethods};
 
@@ -1481,7 +1481,7 @@ impl<'py, T, D> PyArrayMethods<'py, T, D> for Bound<'py, PyArray<T, D>> {
 
     #[inline(always)]
     fn data(&self) -> *mut T {
-        unsafe { (*self.as_array_ptr()).data.cast() }
+        unsafe { (*_PyArray_GET_ITEM_DATA(self.as_array_ptr())).data.cast() }
     }
 
     #[inline(always)]

--- a/src/borrow/mod.rs
+++ b/src/borrow/mod.rs
@@ -182,7 +182,7 @@ use crate::convert::NpyIndex;
 use crate::dtype::Element;
 use crate::error::{AsSliceError, BorrowError};
 use crate::npyffi;
-use crate::npyffi::flags;
+use crate::npyffi::{_PyArray_GET_ITEM_DATA, flags};
 use crate::untyped_array::PyUntypedArrayMethods;
 
 use shared::{acquire, acquire_mut, release, release_mut};
@@ -538,7 +538,7 @@ where
         // SAFETY: consuming the only extant mutable reference guarantees we cannot invalidate an
         // existing reference, nor allow the caller to keep hold of one.
         unsafe {
-            (*self.as_array_ptr()).flags &= !flags::NPY_ARRAY_WRITEABLE;
+            (*_PyArray_GET_ITEM_DATA(self.as_array_ptr())).flags &= !flags::NPY_ARRAY_WRITEABLE;
         }
         self.into()
     }

--- a/src/borrow/shared.rs
+++ b/src/borrow/shared.rs
@@ -15,7 +15,9 @@ use rustc_hash::FxHashMap;
 use crate::array::get_array_module;
 use crate::cold;
 use crate::error::BorrowError;
-use crate::npyffi::{PyArrayObject, PyArray_Check, PyDataType_ELSIZE, NPY_ARRAY_WRITEABLE};
+use crate::npyffi::{
+    _PyArray_GET_ITEM_DATA, PyArrayObject, PyArray_Check, PyDataType_ELSIZE, NPY_ARRAY_WRITEABLE,
+};
 
 /// Defines the shared C API used for borrow checking
 ///
@@ -57,7 +59,7 @@ unsafe extern "C" fn acquire_shared(flags: *mut c_void, array: *mut PyArrayObjec
 }
 
 unsafe extern "C" fn acquire_mut_shared(flags: *mut c_void, array: *mut PyArrayObject) -> c_int {
-    if (*array).flags & NPY_ARRAY_WRITEABLE == 0 {
+    if (*_PyArray_GET_ITEM_DATA(array)).flags & NPY_ARRAY_WRITEABLE == 0 {
         return -2;
     }
 
@@ -368,7 +370,7 @@ impl BorrowFlags {
 
 fn base_address<'py>(py: Python<'py>, mut array: *mut PyArrayObject) -> *mut c_void {
     loop {
-        let base = unsafe { (*array).base };
+        let base = unsafe { (*_PyArray_GET_ITEM_DATA(array)).base };
 
         if base.is_null() {
             return array as *mut c_void;
@@ -383,7 +385,7 @@ fn base_address<'py>(py: Python<'py>, mut array: *mut PyArrayObject) -> *mut c_v
 fn borrow_key<'py>(py: Python<'py>, array: *mut PyArrayObject) -> BorrowKey {
     let range = data_range(py, array);
 
-    let data_ptr = unsafe { (*array).data };
+    let data_ptr = unsafe { (*_PyArray_GET_ITEM_DATA(array)).data };
     let gcd_strides = gcd_strides(array);
 
     BorrowKey {
@@ -394,6 +396,7 @@ fn borrow_key<'py>(py: Python<'py>, array: *mut PyArrayObject) -> BorrowKey {
 }
 
 fn data_range<'py>(py: Python<'py>, array: *mut PyArrayObject) -> (*mut c_char, *mut c_char) {
+    let array = unsafe { _PyArray_GET_ITEM_DATA(array) };
     let nd = unsafe { (*array).nd } as usize;
     let data = unsafe { (*array).data };
 
@@ -430,6 +433,7 @@ fn data_range<'py>(py: Python<'py>, array: *mut PyArrayObject) -> (*mut c_char, 
 }
 
 fn gcd_strides(array: *mut PyArrayObject) -> isize {
+    let array = unsafe { _PyArray_GET_ITEM_DATA(array) };
     let nd = unsafe { (*array).nd } as usize;
 
     if nd == 0 {
@@ -492,7 +496,7 @@ mod tests {
         Python::attach(|py| {
             let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
 
-            let base = unsafe { (*array.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(array.as_array_ptr().cast_const())).base };
             assert!(base.is_null());
 
             let base_address = base_address(py, array.as_array_ptr());
@@ -509,7 +513,7 @@ mod tests {
         Python::attach(|py| {
             let array = Array::<f64, _>::zeros((1, 2, 3)).into_pyarray(py);
 
-            let base = unsafe { (*array.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(array.as_array_ptr().cast_const())).base };
             assert!(!base.is_null());
 
             let base_address = base_address(py, array.as_array_ptr());
@@ -540,7 +544,7 @@ mod tests {
                 array.as_ptr().cast::<c_void>()
             );
 
-            let base = unsafe { (*view.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(view.as_array_ptr().cast_const())).base };
             assert_eq!(base as *mut c_void, array.as_ptr().cast::<c_void>());
 
             let base_address = base_address(py, view.as_array_ptr());
@@ -569,10 +573,10 @@ mod tests {
                 array.as_ptr().cast::<c_void>(),
             );
 
-            let base = unsafe { (*view.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(view.as_array_ptr().cast_const())).base };
             assert_eq!(base.cast::<c_void>(), array.as_ptr().cast::<c_void>());
 
-            let base = unsafe { (*array.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(array.as_array_ptr().cast_const())).base };
             assert!(!base.is_null());
 
             let base_address = base_address(py, view.as_array_ptr());
@@ -619,10 +623,10 @@ mod tests {
                 view1.as_ptr().cast::<c_void>()
             );
 
-            let base = unsafe { (*view2.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(view2.as_array_ptr().cast_const())).base };
             assert_eq!(base as *mut c_void, array.as_ptr().cast::<c_void>());
 
-            let base = unsafe { (*view1.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(view1.as_array_ptr().cast_const())).base };
             assert_eq!(base as *mut c_void, array.as_ptr().cast::<c_void>());
 
             let base_address = base_address(py, view2.as_array_ptr());
@@ -667,13 +671,13 @@ mod tests {
                 view1.as_ptr().cast::<c_void>(),
             );
 
-            let base = unsafe { (*view2.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(view2.as_array_ptr().cast_const())).base };
             assert_eq!(base.cast::<c_void>(), array.as_ptr().cast::<c_void>());
 
-            let base = unsafe { (*view1.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(view1.as_array_ptr().cast_const())).base };
             assert_eq!(base.cast::<c_void>(), array.as_ptr().cast::<c_void>());
 
-            let base = unsafe { (*array.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(array.as_array_ptr().cast_const())).base };
             assert!(!base.is_null());
 
             let base_address = base_address(py, view2.as_array_ptr());
@@ -706,7 +710,7 @@ mod tests {
                 array.as_ptr().cast::<c_void>()
             );
 
-            let base = unsafe { (*view.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(view.as_array_ptr().cast_const())).base };
             assert_eq!(base.cast::<c_void>(), array.as_ptr().cast::<c_void>());
 
             let base_address = base_address(py, view.as_array_ptr());
@@ -727,7 +731,7 @@ mod tests {
         Python::attach(|py| {
             let array = PyArray::<f64, _>::zeros(py, (1, 0, 3), false);
 
-            let base = unsafe { (*array.as_array_ptr()).base };
+            let base = unsafe { (*_PyArray_GET_ITEM_DATA(array.as_array_ptr().cast_const())).base };
             assert!(base.is_null());
 
             let base_address = base_address(py, array.as_array_ptr());

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -17,9 +17,9 @@ use pyo3::{
 };
 
 use crate::npyffi::{
-    self, NpyTypes, PyArray_Descr, PyDataType_ALIGNMENT, PyDataType_ELSIZE, PyDataType_FIELDS,
-    PyDataType_FLAGS, PyDataType_NAMES, PyDataType_SUBARRAY, NPY_ALIGNED_STRUCT,
-    NPY_BYTEORDER_CHAR, NPY_ITEM_HASOBJECT, NPY_TYPES, PY_ARRAY_API,
+    self, _PyDataType_GET_ITEM_DATA, NpyTypes, PyArray_Descr, PyDataType_ALIGNMENT,
+    PyDataType_ELSIZE, PyDataType_FIELDS, PyDataType_FLAGS, PyDataType_NAMES, PyDataType_SUBARRAY,
+    NPY_ALIGNED_STRUCT, NPY_BYTEORDER_CHAR, NPY_ITEM_HASOBJECT, NPY_TYPES, PY_ARRAY_API,
 };
 
 pub use num_complex::{Complex32, Complex64};
@@ -159,7 +159,7 @@ pub trait PyArrayDescrMethods<'py>: Sealed {
     /// [enumerated-types]: https://numpy.org/doc/stable/reference/c-api/dtype.html#enumerated-types
     /// [dtype-num]: https://numpy.org/doc/stable/reference/generated/numpy.dtype.num.html
     fn num(&self) -> c_int {
-        unsafe { &*self.as_dtype_ptr() }.type_num
+        unsafe { &*_PyDataType_GET_ITEM_DATA(self.as_dtype_ptr()) }.type_num
     }
 
     /// Returns the element size of this type descriptor.
@@ -184,7 +184,9 @@ pub trait PyArrayDescrMethods<'py>: Sealed {
     ///
     /// [dtype-byteorder]: https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html
     fn byteorder(&self) -> u8 {
-        unsafe { &*self.as_dtype_ptr() }.byteorder.max(0) as _
+        unsafe { &*_PyDataType_GET_ITEM_DATA(self.as_dtype_ptr()) }
+            .byteorder
+            .max(0) as _
     }
 
     /// Returns a unique ASCII character for each of the 21 different built-in types.
@@ -195,7 +197,9 @@ pub trait PyArrayDescrMethods<'py>: Sealed {
     ///
     /// [dtype-char]: https://numpy.org/doc/stable/reference/generated/numpy.dtype.char.html
     fn char(&self) -> u8 {
-        unsafe { &*self.as_dtype_ptr() }.type_.max(0) as _
+        unsafe { &*_PyDataType_GET_ITEM_DATA(self.as_dtype_ptr()) }
+            .type_
+            .max(0) as _
     }
 
     /// Returns an ASCII character (one of `biufcmMOSUV`) identifying the general kind of data.
@@ -206,7 +210,9 @@ pub trait PyArrayDescrMethods<'py>: Sealed {
     ///
     /// [dtype-kind]: https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html
     fn kind(&self) -> u8 {
-        unsafe { &*self.as_dtype_ptr() }.kind.max(0) as _
+        unsafe { &*_PyDataType_GET_ITEM_DATA(self.as_dtype_ptr()) }
+            .kind
+            .max(0) as _
     }
 
     /// Returns bit-flags describing how this type descriptor is to be interpreted.
@@ -330,7 +336,7 @@ impl<'py> PyArrayDescrMethods<'py> for Bound<'py, PyArrayDescr> {
     }
 
     fn typeobj(&self) -> Bound<'py, PyType> {
-        let dtype_type_ptr = unsafe { &*self.as_dtype_ptr() }.typeobj;
+        let dtype_type_ptr = unsafe { &*_PyDataType_GET_ITEM_DATA(self.as_dtype_ptr()) }.typeobj;
         unsafe { PyType::from_borrowed_type_ptr(self.py(), dtype_type_ptr) }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,3 +181,6 @@ macro_rules! pyarray {
         $crate::IntoPyArray::into_pyarray($crate::array![$($x,)*], $py)
     }};
 }
+
+#[cfg(all(not(Py_3_15), Py_GIL_DISABLED, target_pointer_width = "32"))]
+compile_error!("free-threaded Python on 32bit platforms is only supported from 3.15+");

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -301,6 +301,7 @@ impl PyArrayAPI {
     impl_api![189; PyArray_LexSort(sort_keys: *mut PyObject, axis: c_int) -> *mut PyObject];
     impl_api![190; PyArray_Round(a: *mut PyArrayObject, decimals: c_int, out: *mut PyArrayObject) -> *mut PyObject];
     impl_api![191; PyArray_EquivTypenums(typenum1: c_int, typenum2: c_int) -> c_uchar];
+    #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
     impl_api![192; PyArray_RegisterDataType(descr: *mut PyArray_DescrProto) -> c_int];
     impl_api![193; PyArray_RegisterCastFunc(descr: *mut PyArray_Descr, totype: c_int, castfunc: PyArray_VectorUnaryFunc) -> c_int];
     impl_api![194; PyArray_RegisterCanCast(descr: *mut PyArray_Descr, totype: c_int, scalar: NPY_SCALARKIND) -> c_int];
@@ -428,6 +429,22 @@ impl PyArrayAPI {
     // Min v2.0 impl_api![363; PyArray_CommonDType(dtype1: *mut PyArray_DTypeMeta, dtype2: *mut PyArray_DTypeMeta) -> PyArray_DTypeMeta];
     // Min v2.0 impl_api![364; PyArray_PromoteDTypeSequence(length: npy_intp, dtypes_in: *mut *mut PyArray_DTypeMeta) -> *mut PyArray_DTypeMeta];
     // Min v2.0 impl_api![365; _PyDataType_GetArrFuncs(descr: *const PyArray_Descr) -> *mut PyArray_ArrFuncs];
+    // Slot 366, 367, 368 are the abstract DTypes
+}
+
+// Min v2.5
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+impl PyArrayAPI {
+    impl_api![369; _PyArray_GET_ITEM_DATA(arr: *const PyArrayObject) -> *mut PyArrayObject_fields];
+    impl_api![370; _PyArrayIter_GET_ITEM_DATA(iter: *const PyArrayIterObject) -> *mut PyArrayIterObject_fields];
+    impl_api![371; pub(crate) _PyArray_LegacyDescr_GET_ITEM_DATA(dtype: *const _PyArray_LegacyDescr) -> *mut _PyArray_LegacyDescr_fields];
+    impl_api![372; _PyDataType_GET_ITEM_DATA(dtype: *const PyArray_Descr) -> *mut PyArray_Descr_fields];
+    impl_api![373; _PyArrayMultiIter_GET_ITEM_DATA(multi: *const PyArrayMultiIterObject) -> *mut PyArrayMultiIterObject_fields];
+    impl_api![374; _PyArrayNeighborhoodIter_GET_ITEM_DATA(iter: *const PyArrayNeighborhoodIterObject) -> *mut PyArrayNeighborhoodIterObject_fields];
+    impl_api![375; _PyDatetimeScalarObject_GetMetadata(obj: *mut PyObject) -> PyArray_DatetimeMetaData];
+    impl_api![376; _PyTimedeltaScalarObject_GetMetadata(obj: *mut PyObject) -> PyArray_DatetimeMetaData];
+    impl_api![377; _PyDatetimeScalarObject_GetValue(obj: *mut PyObject) -> npy_datetime];
+    impl_api![378; _PyTimedeltaScalarObject_GetValue(obj: *mut PyObject) -> npy_timedelta];
 }
 
 /// Checks that `op` is an instance of `PyArray` or not.

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -58,12 +58,15 @@ pub fn is_numpy_2<'py>(py: Python<'py>) -> bool {
 macro_rules! impl_api {
     // API available on all versions
     [$offset: expr; $fname: ident ($($arg: ident: $t: ty),* $(,)?) $(-> $ret: ty)?] => {
+        impl_api![$offset; pub $fname($($arg : $t), *) $(-> $ret)*];
+    };
+    [$offset: expr; $vis:vis $fname: ident ($($arg: ident: $t: ty),* $(,)?) $(-> $ret: ty)?] => {
         #[allow(non_snake_case)]
-        pub unsafe fn $fname<'py>(&self, py: Python<'py>, $($arg : $t), *) $(-> $ret)* {
+        $vis unsafe fn $fname<'py>(&self, py: Python<'py>, $($arg : $t), *) $(-> $ret)* {
             let f: extern "C" fn ($($arg : $t), *) $(-> $ret)* = self.get(py, $offset).cast().read();
             f($($arg), *)
         }
-    };
+    }
 }
 
 // Define type objects associated with the NumPy API
@@ -80,6 +83,21 @@ macro_rules! impl_array_type {
             }
         }
     }
+}
+
+// Until `extern type` is stabilized, use the recommended approach to
+// model opaque types:
+// https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+macro_rules! opaque_struct {
+    ($(#[$attrs:meta])* $pub:vis $name:ident) => {
+        $(#[$attrs])*
+        #[repr(C)]
+        $pub struct $name {
+            _data: (),
+            _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+        }
+    };
 }
 
 impl_array_type! {

--- a/src/npyffi/numpyconfig.rs
+++ b/src/npyffi/numpyconfig.rs
@@ -5,8 +5,14 @@ use std::ffi::c_uint;
 /// The current target ABI version
 const NPY_ABI_VERSION: c_uint = 0x02000000;
 
-/// The current target API version (v1.15)
-const NPY_API_VERSION: c_uint = 0x0000000c;
+/// The current target API version
+const NPY_API_VERSION: c_uint = if cfg!(all(Py_LIMITED_API, Py_GIL_DISABLED)) {
+    // (v2.5)
+    0x00000016
+} else {
+    // (v1.15)
+    0x0000000c
+};
 
 pub(super) const NPY_2_0_API_VERSION: c_uint = 0x00000012;
 
@@ -15,4 +21,8 @@ pub const NPY_VERSION: c_uint = NPY_ABI_VERSION;
 /// The current version of C API.
 pub const NPY_FEATURE_VERSION: c_uint = NPY_API_VERSION;
 /// The string representation of current version C API.
-pub const NPY_FEATURE_VERSION_STRING: &str = "1.15";
+pub const NPY_FEATURE_VERSION_STRING: &str = if cfg!(all(Py_LIMITED_API, Py_GIL_DISABLED)) {
+    "2.5"
+} else {
+    "1.15"
+};

--- a/src/npyffi/objects.rs
+++ b/src/npyffi/objects.rs
@@ -14,8 +14,8 @@ pub const NPY_NTYPES_ABI_COMPATIBLE: usize = 21;
 pub const NPY_MAXDIMS_LEGACY_ITERS: usize = 32;
 
 #[repr(C)]
-pub struct PyArrayObject {
-    pub ob_base: PyObject,
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub struct PyArrayObject_fields {
     pub data: *mut c_char,
     pub nd: c_int,
     pub dimensions: *mut npy_intp,
@@ -26,9 +26,20 @@ pub struct PyArrayObject {
     pub weakreflist: *mut PyObject,
 }
 
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub PyArrayObject);
+
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
 #[repr(C)]
-pub struct PyArray_Descr {
+pub struct PyArrayObject {
     pub ob_base: PyObject,
+    pub fields: PyArrayObject_fields,
+}
+
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+#[repr(C)]
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub struct PyArray_Descr_fields {
     pub typeobj: *mut PyTypeObject,
     pub kind: c_char,
     pub type_: c_char,
@@ -37,6 +48,21 @@ pub struct PyArray_Descr {
     pub type_num: c_int,
 }
 
+#[doc(inline)]
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+pub use _PyArray_DescrNumPy2_fields as PyArray_Descr_fields;
+
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+#[repr(C)]
+pub struct PyArray_Descr {
+    pub ob_base: PyObject,
+    pub fields: PyArray_Descr_fields,
+}
+
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub PyArray_Descr);
+
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
 #[repr(C)]
 pub struct PyArray_DescrProto {
     pub ob_base: PyObject,
@@ -58,8 +84,8 @@ pub struct PyArray_DescrProto {
 }
 
 #[repr(C)]
-pub struct _PyArray_DescrNumPy2 {
-    pub ob_base: PyObject,
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub struct _PyArray_DescrNumPy2_fields {
     pub typeobj: *mut PyTypeObject,
     pub kind: c_char,
     pub type_: c_char,
@@ -75,8 +101,8 @@ pub struct _PyArray_DescrNumPy2 {
 }
 
 #[repr(C)]
-struct _PyArray_LegacyDescr {
-    pub ob_base: PyObject,
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub(crate) struct _PyArray_LegacyDescr_fields {
     pub typeobj: *mut PyTypeObject,
     pub kind: c_char,
     pub type_: c_char,
@@ -95,9 +121,67 @@ struct _PyArray_LegacyDescr {
     pub c_metadata: *mut NpyAuxData,
 }
 
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+#[repr(C)]
+pub(crate) struct _PyArray_LegacyDescr {
+    pub _ob_base: PyObject,
+    pub fields: _PyArray_LegacyDescr_fields,
+}
+
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub(crate) _PyArray_LegacyDescr);
+
+/// # Safety
+/// - attached Python thread-state
+#[allow(non_snake_case)]
+#[inline(always)]
+pub unsafe fn _PyArray_GET_ITEM_DATA(arr: *const PyArrayObject) -> *mut PyArrayObject_fields {
+    #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+    {
+        PY_ARRAY_API._PyArray_GET_ITEM_DATA(Python::assume_attached(), arr)
+    }
+    #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+    {
+        &raw mut (*arr.cast_mut()).fields
+    }
+}
+
+/// # Safety
+/// - attached Python thread-state
+#[allow(non_snake_case)]
+#[inline(always)]
+pub unsafe fn _PyDataType_GET_ITEM_DATA(dtype: *const PyArray_Descr) -> *mut PyArray_Descr_fields {
+    #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+    {
+        PY_ARRAY_API._PyDataType_GET_ITEM_DATA(Python::assume_attached(), dtype)
+    }
+    #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+    {
+        &raw mut (*dtype.cast_mut()).fields
+    }
+}
+
+/// # Safety
+/// - attached Python thread-state
+#[allow(non_snake_case)]
+#[inline(always)]
+unsafe fn _PyArray_LegacyDescr_GET_ITEM_DATA(
+    dtype: *const _PyArray_LegacyDescr,
+) -> *mut _PyArray_LegacyDescr_fields {
+    #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+    {
+        PY_ARRAY_API._PyArray_LegacyDescr_GET_ITEM_DATA(Python::assume_attached(), dtype)
+    }
+    #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+    {
+        &raw mut (*dtype.cast_mut()).fields
+    }
+}
+
 #[allow(non_snake_case)]
 #[inline(always)]
 pub unsafe fn PyDataType_ISLEGACY(dtype: *const PyArray_Descr) -> bool {
+    let dtype = _PyDataType_GET_ITEM_DATA(dtype);
     (*dtype).type_num < NPY_TYPES::NPY_VSTRING as _ && (*dtype).type_num >= 0
 }
 
@@ -108,24 +192,38 @@ pub unsafe fn PyDataType_SET_ELSIZE<'py>(
     dtype: *mut PyArray_Descr,
     size: npy_intp,
 ) {
+    #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
     if is_numpy_2(py) {
         unsafe {
-            (*(dtype as *mut _PyArray_DescrNumPy2)).elsize = size;
+            (*_PyDataType_GET_ITEM_DATA(dtype).cast::<_PyArray_DescrNumPy2_fields>()).elsize = size;
         }
     } else {
-        unsafe {
-            (*(dtype as *mut PyArray_DescrProto)).elsize = size as c_int;
-        }
+        // Numpy 1 does not support abi3t, so direct field access is fine
+        unsafe { (*dtype.cast::<PyArray_DescrProto>()).elsize = size as c_int }
+    }
+
+    #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+    unsafe {
+        debug_assert!(is_numpy_2(py));
+        (*_PyDataType_GET_ITEM_DATA(dtype)).elsize = size;
     }
 }
 
 #[allow(non_snake_case)]
 #[inline(always)]
 pub unsafe fn PyDataType_FLAGS<'py>(py: Python<'py>, dtype: *const PyArray_Descr) -> npy_uint64 {
+    #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
     if is_numpy_2(py) {
-        unsafe { (*(dtype as *mut _PyArray_DescrNumPy2)).flags }
+        unsafe { (*_PyDataType_GET_ITEM_DATA(dtype).cast::<_PyArray_DescrNumPy2_fields>()).flags }
     } else {
-        unsafe { (*(dtype as *mut PyArray_DescrProto)).flags as c_uchar as npy_uint64 }
+        // Numpy 1 does not support abi3t, so direct field access is fine
+        unsafe { (*dtype.cast::<PyArray_DescrProto>()).flags as c_uchar as npy_uint64 }
+    }
+
+    #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+    unsafe {
+        debug_assert!(is_numpy_2(py));
+        (*_PyDataType_GET_ITEM_DATA(dtype)).flags
     }
 }
 
@@ -137,10 +235,18 @@ macro_rules! define_descr_accessor {
             if $legacy_only && !PyDataType_ISLEGACY(dtype) {
                 $default
             } else {
+                #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
                 if is_numpy_2(py) {
-                    unsafe { (*(dtype as *const _PyArray_LegacyDescr)).$property }
+                    unsafe { (*_PyArray_LegacyDescr_GET_ITEM_DATA(dtype.cast())).$property }
                 } else {
-                    unsafe { (*(dtype as *mut PyArray_DescrProto)).$property as $type }
+                    // Numpy 1 does not support abi3t, so direct field access is fine
+                    unsafe { (*dtype.cast::<PyArray_DescrProto>()).$property as $type }
+                }
+
+                #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+                unsafe {
+                    debug_assert!(is_numpy_2(py));
+                    (*_PyArray_LegacyDescr_GET_ITEM_DATA(dtype.cast())).$property
                 }
             }
         }
@@ -301,8 +407,8 @@ pub struct PyArrayInterface {
 }
 
 #[repr(C)]
-pub struct PyUFuncObject {
-    pub ob_base: PyObject,
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub struct PyUFuncObject_fields {
     pub nin: c_int,
     pub nout: c_int,
     pub nargs: c_int,
@@ -334,6 +440,16 @@ pub struct PyUFuncObject {
     pub iter_flags: npy_uint32,
 }
 
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+#[repr(C)]
+pub struct PyUFuncObject {
+    pub ob_base: PyObject,
+    pub fields: PyUFuncObject_fields,
+}
+
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub PyUFuncObject);
+
 pub type PyUFuncGenericFunction =
     Option<unsafe extern "C" fn(*mut *mut c_char, *mut npy_intp, *mut npy_intp, *mut c_void)>;
 pub type PyUFunc_MaskedStridedInnerLoopFunc = Option<
@@ -361,8 +477,8 @@ pub type PyUFunc_TypeResolutionFunc = Option<
 pub struct NpyIter([u8; 0]);
 
 #[repr(C)]
-pub struct PyArrayIterObject {
-    pub ob_base: PyObject,
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub struct PyArrayIterObject_fields {
     pub nd_m1: c_int,
     pub index: npy_intp,
     pub size: npy_intp,
@@ -380,9 +496,19 @@ pub struct PyArrayIterObject {
     pub translate: npy_iter_get_dataptr_t,
 }
 
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
 #[repr(C)]
-pub struct PyArrayMultiIterObject {
+pub struct PyArrayIterObject {
     pub ob_base: PyObject,
+    pub fields: PyArrayIterObject_fields,
+}
+
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub PyArrayIterObject);
+
+#[repr(C)]
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub struct PyArrayMultiIterObject_fields {
     pub numiter: c_int,
     pub size: npy_intp,
     pub index: npy_intp,
@@ -391,9 +517,19 @@ pub struct PyArrayMultiIterObject {
     pub iters: [*mut PyArrayIterObject; 32usize],
 }
 
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
 #[repr(C)]
-pub struct PyArrayNeighborhoodIterObject {
+pub struct PyArrayMultiIterObject {
     pub ob_base: PyObject,
+    pub fields: PyArrayMultiIterObject_fields,
+}
+
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub PyArrayMultiIterObject);
+
+#[repr(C)]
+#[cfg_attr(Py_3_15, repr(align(8)))]
+pub struct PyArrayNeighborhoodIterObject_fields {
     pub nd_m1: c_int,
     pub index: npy_intp,
     pub size: npy_intp,
@@ -415,6 +551,16 @@ pub struct PyArrayNeighborhoodIterObject {
     pub constant: *mut c_char,
     pub mode: c_int,
 }
+
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
+#[repr(C)]
+pub struct PyArrayNeighborhoodIterObject {
+    pub ob_base: PyObject,
+    pub fields: PyArrayNeighborhoodIterObject_fields,
+}
+
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub PyArrayNeighborhoodIterObject);
 
 pub type NpyIter_IterNextFunc = Option<unsafe extern "C" fn(*mut NpyIter) -> c_int>;
 pub type NpyIter_GetMultiIndexFunc = Option<unsafe extern "C" fn(*mut NpyIter, *mut npy_intp)>;
@@ -479,6 +625,7 @@ pub struct npy_static_string {
     pub buf: *const c_char,
 }
 
+#[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
 #[repr(C)]
 pub struct PyArray_StringDTypeObject {
     pub base: PyArray_Descr,
@@ -491,6 +638,9 @@ pub struct PyArray_StringDTypeObject {
     pub na_name: npy_static_string,
     pub allocator: *mut npy_string_allocator,
 }
+
+#[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+opaque_struct!(pub PyArray_StringDTypeObject);
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -105,4 +105,9 @@ impl PyUFuncAPI {
     //     translate_given_descrs: *mut PyArrayMethod_TranslateGivenDescriptors,
     //     translate_loop_descrs: *mut PyArrayMethod_TranslateLoopDescriptors) -> c_int];
     // Min v2.0 impl_api![46; PyUFunc_GiveFloatingpointErrors(name: *mut c_char, fpe_errors: c_int) -> c_int];
+    // Min v2.4 impl_api![47; PyUFunc_AddLoopsFromSpecs(slots: *mut PyUFunc_LoopSlot) -> c_int];
+
+    // Min v2.5
+    #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+    impl_api![48; _PyUFuncObject_GET_ITEM_DATA(obj: *const PyUFuncObject) -> *mut PyUFuncObject_fields];
 }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -18,8 +18,7 @@ use pyo3::{
 use rustc_hash::FxHashMap;
 
 use crate::dtype::{clone_methods_impl, Element, PyArrayDescr, PyArrayDescrMethods};
-use crate::npyffi::PyDataType_SET_ELSIZE;
-use crate::npyffi::NPY_TYPES;
+use crate::npyffi::{_PyDataType_GET_ITEM_DATA, PyDataType_SET_ELSIZE, NPY_TYPES};
 
 /// A newtype wrapper around [`[u8; N]`][Py_UCS1] to handle [`byte` scalars][numpy-bytes] while satisfying coherence.
 ///
@@ -191,7 +190,7 @@ impl TypeDescriptors {
 
                 let descr = &mut *dtype.as_dtype_ptr();
                 PyDataType_SET_ELSIZE(py, descr, size.try_into().unwrap());
-                descr.byteorder = byteorder;
+                (*_PyDataType_GET_ITEM_DATA(descr)).byteorder = byteorder;
 
                 entry.insert(dtype.into())
             }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -205,6 +205,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::byte_char_slices)]
     fn format_fixed_string() {
         assert_eq!(
             PyFixedString([b'f', b'o', b'o', 0, 0, 0]).to_string(),

--- a/src/untyped_array.rs
+++ b/src/untyped_array.rs
@@ -8,7 +8,7 @@ use pyo3::{ffi, pyobject_native_type_named, Bound, PyAny, PyTypeInfo, Python};
 use crate::array::{PyArray, PyArrayMethods};
 use crate::cold;
 use crate::dtype::PyArrayDescr;
-use crate::npyffi;
+use crate::npyffi::{self, _PyArray_GET_ITEM_DATA};
 
 /// A safe, untyped wrapper for NumPy's [`ndarray`] class.
 ///
@@ -197,7 +197,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
     /// [PyArray_NDIM]: https://numpy.org/doc/stable/reference/c-api/array.html#c.PyArray_NDIM
     #[inline]
     fn ndim(&self) -> usize {
-        unsafe { (*self.as_array_ptr()).nd as usize }
+        unsafe { (*_PyArray_GET_ITEM_DATA(self.as_array_ptr().cast_const())).nd as usize }
     }
 
     /// Returns a slice indicating how many bytes to advance when iterating along each axis.
@@ -225,7 +225,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
             cold();
             return &[];
         }
-        let ptr = self.as_array_ptr();
+        let ptr = unsafe { _PyArray_GET_ITEM_DATA(self.as_array_ptr().cast_const()) };
         unsafe {
             let p = (*ptr).strides;
             slice::from_raw_parts(p, n)
@@ -258,7 +258,7 @@ pub trait PyUntypedArrayMethods<'py>: Sealed {
             cold();
             return &[];
         }
-        let ptr = self.as_array_ptr();
+        let ptr = unsafe { _PyArray_GET_ITEM_DATA(self.as_array_ptr().cast_const()) };
         unsafe {
             let p = (*ptr).dimensions as *mut usize;
             slice::from_raw_parts(p, n)
@@ -283,7 +283,7 @@ mod sealed {
 use sealed::Sealed;
 
 fn check_flags(obj: &npyffi::PyArrayObject, flags: i32) -> bool {
-    obj.flags & flags != 0
+    unsafe { (*_PyArray_GET_ITEM_DATA(obj)).flags & flags != 0 }
 }
 
 impl<'py> PyUntypedArrayMethods<'py> for Bound<'py, PyUntypedArray> {
@@ -294,7 +294,8 @@ impl<'py> PyUntypedArrayMethods<'py> for Bound<'py, PyUntypedArray> {
 
     fn dtype(&self) -> Bound<'py, PyArrayDescr> {
         unsafe {
-            let descr_ptr = (*self.as_array_ptr()).descr;
+            let descr_ptr =
+                (*npyffi::_PyArray_GET_ITEM_DATA(self.as_array_ptr().cast_const())).descr;
             Bound::from_borrowed_ptr(self.py(), descr_ptr.cast()).cast_into_unchecked()
         }
     }

--- a/tests/borrow.rs
+++ b/tests/borrow.rs
@@ -1,8 +1,9 @@
 use std::thread::spawn;
 
 use numpy::{
-    array::PyArrayMethods, npyffi::NPY_ARRAY_WRITEABLE, PyArray, PyArray1, PyArray2,
-    PyReadonlyArray3, PyReadwriteArray3, PyUntypedArrayMethods,
+    array::PyArrayMethods,
+    npyffi::{_PyArray_GET_ITEM_DATA, NPY_ARRAY_WRITEABLE},
+    PyArray, PyArray1, PyArray2, PyReadonlyArray3, PyReadwriteArray3, PyUntypedArrayMethods,
 };
 use pyo3::{
     ffi::c_str,
@@ -78,7 +79,8 @@ fn exclusive_borrow_requires_writeable() {
         let array = PyArray::<f64, _>::zeros(py, (1, 2, 3), false);
 
         unsafe {
-            (*array.as_array_ptr()).flags &= !NPY_ARRAY_WRITEABLE;
+            (*_PyArray_GET_ITEM_DATA(array.as_array_ptr().cast_const())).flags &=
+                !NPY_ARRAY_WRITEABLE;
         }
 
         let err = array.try_readwrite().unwrap_err();


### PR DESCRIPTION
This adds abi3t support by
- switching to opaque structs
- exposing data access helpers from slots 369-378
- redirect all field accesses through the access helpers

Todo:
- [x] changelog entry
- [x] CI testing for 3.15/3.15t

See numpy/numpy#31091
Closes #555 