### PR TITLE
Fix panic in as_array/as_array_mut for arrays with a zero-length dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Unreleased
   - `PyReadonlyArray`/`PyReadwriteArray` extraction now returns a `PyErr` which reports the actual dtype/dimensionality mismatch instead of nonsensical `CastError` messages like “'ndarray' is not an instance of 'ndarray'” ([#562](https://github.com/PyO3/rust-numpy/pull/562))
+  - Fix a panic in `as_array`/`as_array_mut` for arrays with a zero-length dimension ([#558](https://github.com/PyO3/rust-numpy/pull/558))
 
 - v0.29.0
   - Fix PyArray_DTypeMeta definition when Py_LIMITED_API is disabled ([#532](https://github.com/PyO3/rust-numpy/pull/532))

--- a/src/array.rs
+++ b/src/array.rs
@@ -1393,6 +1393,21 @@ where
             }
         }
 
+        // NumPy reports zero strides for arrays that have a zero-length axis.
+        // ndarray's view constructors reject a zero stride on an axis of length
+        // greater than one, because that would let two indices alias the same
+        // element, and panic even though a zero-element array cannot alias
+        // anything. Substitute clamped C-contiguous strides in that case; the
+        // data pointer is never dereferenced for an empty array, so the
+        // fabricated strides are sound for both immutable and mutable views.
+        if shape.size() == 0 {
+            let mut acc = 1;
+            for i in (0..strides.len()).rev() {
+                new_strides[i] = acc;
+                acc *= shape[i].max(1);
+            }
+        }
+
         (shape.strides(new_strides), inverted_axes, data_ptr)
     }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -172,6 +172,35 @@ fn as_array() {
 }
 
 #[test]
+fn as_array_zero_sized_dimension() {
+    // Regression test for https://github.com/PyO3/rust-numpy/issues/527:
+    // NumPy reports zero strides for arrays with a zero-length axis, which
+    // used to make the (mutable) ndarray view constructor panic even though
+    // an empty array cannot alias any element.
+    Python::attach(|py| {
+        let arr = PyArray2::<f64>::zeros(py, [2, 0], false);
+        {
+            let view = arr.readonly();
+            assert_eq!(view.as_array().shape(), &[2, 0]);
+        }
+        {
+            let mut view = arr.readwrite();
+            assert_eq!(view.as_array_mut().shape(), &[2, 0]);
+        }
+
+        // A leading zero-length axis is handled as well.
+        let arr = PyArray2::<f64>::zeros(py, [0, 2], false);
+        assert_eq!(arr.readonly().as_array().shape(), &[0, 2]);
+        assert_eq!(arr.readwrite().as_array_mut().shape(), &[0, 2]);
+
+        // Higher-rank arrays with an interior zero-length axis too.
+        let arr = PyArray::<f64, _>::zeros(py, [2, 0, 3], false);
+        assert_eq!(arr.readonly().as_array().shape(), &[2, 0, 3]);
+        assert_eq!(arr.readwrite().as_array_mut().shape(), &[2, 0, 3]);
+    });
+}
+
+#[test]
 fn as_raw_array() {
     Python::attach(|py| {
         let not_contiguous = not_contiguous_array(py);


### PR DESCRIPTION
NumPy reports zero strides for arrays that have a zero-length axis (e.g. shape `[2, 0]` → strides `(0, 0)`). `as_view` passed these straight into ndarray's `from_shape_ptr`, whose aliasing check rejects a zero stride on an axis of length > 1 and panics ("The strides must not allow any element to be referenced by two different indices") — even though the array holds no elements and cannot alias anything. This affected both `as_array` and `as_array_mut`.

Fix: in `as_view`'s `inner`, when the shape has size 0, substitute clamped C-contiguous strides (computed from `shape[i].max(1)`). The data pointer is never dereferenced for an empty array, so the fabricated strides are sound for both immutable and mutable views. Keeps the existing infallible signature (no breaking `Result` change).

Adds a regression test covering `[2, 0]` (immutable + mutable), `[0, 2]`, and 3-D `[2, 0, 3]`.

Closes #527.
