### PR TITLE
Fix dtype layout tests on 32-bit targets

### DIFF
--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -725,6 +725,9 @@ mod tests {
             assert_eq!(dt.byteorder(), b'=');
             assert_eq!(dt.is_native_byteorder(), Some(true));
             assert_eq!(dt.itemsize(), 8);
+            #[cfg(target_pointer_width = "32")]
+            assert_eq!(dt.alignment(), 4);
+            #[cfg(target_pointer_width = "64")]
             assert_eq!(dt.alignment(), 8);
             assert!(!dt.has_object());
             assert!(dt.names().is_none());
@@ -761,6 +764,9 @@ mod tests {
             assert_eq!(dt.byteorder(), b'|');
             assert_eq!(dt.is_native_byteorder(), None);
             assert_eq!(dt.itemsize(), 48);
+            #[cfg(target_pointer_width = "32")]
+            assert_eq!(dt.alignment(), 4);
+            #[cfg(target_pointer_width = "64")]
             assert_eq!(dt.alignment(), 8);
             assert!(!dt.has_object());
             assert!(dt.names().is_none());
@@ -798,8 +804,16 @@ mod tests {
             assert_eq!(dt.kind(), b'V');
             assert_eq!(dt.byteorder(), b'|');
             assert_eq!(dt.is_native_byteorder(), None);
-            assert_eq!(dt.itemsize(), 24);
-            assert_eq!(dt.alignment(), 8);
+            #[cfg(target_pointer_width = "32")]
+            {
+                assert_eq!(dt.itemsize(), 16);
+                assert_eq!(dt.alignment(), 4);
+            }
+            #[cfg(target_pointer_width = "64")]
+            {
+                assert_eq!(dt.itemsize(), 24);
+                assert_eq!(dt.alignment(), 8);
+            }
             assert!(dt.has_object());
             assert_eq!(
                 dt.names(),


### PR DESCRIPTION
Make dtype alignment and aligned-record layout tests portable to 32-bit targets.

On i386, NumPy reports 4-byte alignment for the tested scalar and subarray dtypes, and the aligned record has itemsize 16 and alignment 4. The tests currently hard-code the 64-bit values 8 and 24, causing `dtype::tests::test_dtype_methods_record` and related tests to fail on i386.

The library behavior is unchanged; the assertions now select the expected values using `target_pointer_width`. This addresses the i386 failure observed while packaging rust-numpy 0.28.0 in Debian.