### PR TITLE
Make borrow-state tests portable on 32-bit targets

### DIFF
--- a/src/borrow/shared.rs
+++ b/src/borrow/shared.rs
@@ -454,7 +454,7 @@ mod tests {
     use pyo3::ffi::c_str;
 
     struct BorrowFlagsState {
-        #[cfg(not(Py_GIL_DISABLED))]
+        #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
         n_flags: usize,
         n_arrays: usize,
         flag: Option<isize>,
@@ -472,14 +472,14 @@ mod tests {
             .unwrap();
         if let Some(base_arrays) = inner.get(&base) {
             BorrowFlagsState {
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 n_flags: inner.len(),
                 n_arrays: base_arrays.len(),
                 flag: base_arrays.get(key).copied(),
             }
         } else {
             BorrowFlagsState {
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 n_flags: 0,
                 n_arrays: 0,
                 flag: None,
@@ -812,7 +812,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base1, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
 
@@ -825,7 +825,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base1, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 2);
 
@@ -859,7 +859,7 @@ mod tests {
             {
                 let state = get_borrow_flags_state(py, base, &key1);
 
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
                 assert_eq!(state.n_arrays, 1);
@@ -877,7 +877,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
                 assert_eq!(state.n_arrays, 2);
@@ -898,7 +898,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
                 assert_eq!(state.n_arrays, 2);
@@ -922,7 +922,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
                 assert_eq!(state.n_arrays, 3);
@@ -942,7 +942,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
                 assert_eq!(state.n_arrays, 3);
@@ -962,7 +962,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
                 assert_eq!(state.n_arrays, 2);
@@ -982,7 +982,7 @@ mod tests {
 
             {
                 let state = get_borrow_flags_state(py, base, &key1);
-                #[cfg(not(Py_GIL_DISABLED))]
+                #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
                 // borrow checking state is shared and other tests might have registered a borrow
                 assert_eq!(state.n_flags, 1);
                 assert_eq!(state.n_arrays, 1);
@@ -1000,7 +1000,7 @@ mod tests {
 
             drop(shared4);
 
-            #[cfg(not(Py_GIL_DISABLED))]
+            #[cfg(all(not(Py_GIL_DISABLED), target_pointer_width = "64"))]
             // borrow checking state is shared and other tests might have registered a borrow
             {
                 assert_eq!(get_borrow_flags_state(py, base, &key1).n_flags, 0);


### PR DESCRIPTION
Fixes #565.

The borrow-state tests assert exact values of the process-global borrow-flag count. On Debian i386, the no-feature test suite can observe an additional registered flag and fail even though the array-count and safety checks remain valid.

Gate the exact `n_flags` state and assertions on 64-bit targets while retaining the other borrow-state checks on all architectures. This keeps the test meaningful without requiring a platform-dependent global registry count on 32-bit systems.

Validation:
- `cargo test --lib borrow::shared::tests::borrow_multiple_arrays` passed.
- `git diff --check` passed.
- Debian's `rust-numpy 0.28.0-4` i386 sbuild passed with the equivalent packaging patch.